### PR TITLE
20250508

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,25 +144,25 @@ new kk_date('2024-01-05').add(-1, 'days').format('YYYY-MM-DD')
 // 2024-01-04
 
 // Set specific date part
-new kk_date('2024-01-05').set(1, 'day').format('YYYY-MM-DD')
+new kk_date('2024-01-05').set(1, 'days').format('YYYY-MM-DD')
 // 2024-01-01
 
 // Set month
-new kk_date('2024-01-05').set(3, 'month').format('YYYY-MM-DD')
+new kk_date('2024-01-05').set(3, 'months').format('YYYY-MM-DD')
 // 2024-03-05
 
 // Get the start of a time unit
-new kk_date('2024-08-19 14:35:45').startOf('day').format('YYYY-MM-DD HH:mm:ss')
+new kk_date('2024-08-19 14:35:45').startOf('days').format('YYYY-MM-DD HH:mm:ss')
 // 2024-08-19 00:00:00
 
-new kk_date('2024-08-19 14:35:45').startOf('month').format('YYYY-MM-DD HH:mm:ss')
+new kk_date('2024-08-19 14:35:45').startOf('months').format('YYYY-MM-DD HH:mm:ss')
 // 2024-08-01 00:00:00
 
 // Get the end of a time unit
-new kk_date('2024-08-19 14:35:45').endOf('day').format('YYYY-MM-DD HH:mm:ss')
+new kk_date('2024-08-19 14:35:45').endOf('days').format('YYYY-MM-DD HH:mm:ss')
 // 2024-08-19 23:59:59
 
-new kk_date('2024-08-19 14:35:45').endOf('month').format('YYYY-MM-DD HH:mm:ss')
+new kk_date('2024-08-19 14:35:45').endOf('months').format('YYYY-MM-DD HH:mm:ss')
 // 2024-08-31 23:59:59
 ```
 
@@ -262,11 +262,11 @@ new kk_date('2024-01-01').config({ locale: 'tr-TR' })
 #### Duration:
 ```javascript
 // Convert seconds to duration object
-kk_date.duration(1234, 'minute')
-// { year: 0, month: 0, week: 0, day: 0, hour: 20, minute: 34, second: 0, millisecond: 0 }
+kk_date.duration(1234, 'minutes')
+// { years: 0, months: 0, weeks: 0, days: 0, hours: 20, minutes: 34, seconds: 0, milliseconds: 0 }
 
 // Getting Duration in Specific Units:
-const dur = kk_date.duration(1.5, 'day'); // 1 day and 12 hours
+const dur = kk_date.duration(1.5, 'days'); // 1 day and 12 hours
 dur.asDays();       // 1.5
 dur.asHours();      // 36
 dur.asMinutes();    // 2160
@@ -278,7 +278,7 @@ dur.asYears();      // ~0.0041...
 
 // Get duration from date
 new kk_date('2024-01-01').duration(1234)
-// { year: 0, month: 0, week: 0, day: 0, hour: 0, minute: 20, second: 34 }
+// { years: 0, months: 0, weeks: 0, days: 0, hours: 0, minutes: 20, seconds: 34 }
 ```
 
 #### Relative Time:

--- a/constants.js
+++ b/constants.js
@@ -1,13 +1,13 @@
 const cache_ttl = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 const timeInMilliseconds = {
-	year: 365 * 24 * 60 * 60 * 1000, // 1 year (365 days)
-	month: 31 * 24 * 60 * 60 * 1000, // 1 month (31 days)
-	week: 7 * 24 * 60 * 60 * 1000, // 1 week (7 days)
-	day: 24 * 60 * 60 * 1000, // 1 day (24 hours)
-	hour: 60 * 60 * 1000, // 1 hour
-	minute: 60 * 1000, // 1 minute
-	second: 1000, // 1 second
+	years: 365 * 24 * 60 * 60 * 1000, // 1 year (365 days)
+	months: 31 * 24 * 60 * 60 * 1000, // 1 month (31 days)
+	weeks: 7 * 24 * 60 * 60 * 1000, // 1 week (7 days)
+	days: 24 * 60 * 60 * 1000, // 1 day (24 hours)
+	hours: 60 * 60 * 1000, // 1 hour
+	minutes: 60 * 1000, // 1 minute
+	seconds: 1000, // 1 second
 };
 
 const format_types = {

--- a/functions.js
+++ b/functions.js
@@ -171,35 +171,35 @@ const padZero = (num) => String(num).padStart(2, '0');
 /**
  * @description It divides the date string into parts and returns an object.
  * @param {string} time
- * @param {"year" | "month" | "week" | "day" | "hour" | "minute" | "second"} type
- * @returns {{year: number, month: number, week:number, day: number, hour: number, minute: number, second: number, millisecond: number, $kk_date: {milliseconds: number}, asMilliseconds: function(): number, asSeconds: function(): number, asMinutes: function(): number, asHours: function(): number, asDays: function(): number, asWeeks: function(): number, asMonths: function(): number, asYears: function(): number}}
+ * @param {"years" | "months" | "weeks" | "days" | "hours" | "minutes" | "seconds"} type
+ * @returns {{years: number, months: number, weeks: number, days: number, hours: number, minutes: number, seconds: number, milliseconds: number, $kk_date: {milliseconds: number}, asMilliseconds: function(): number, asSeconds: function(): number, asMinutes: function(): number, asHours: function(): number, asDays: function(): number, asWeeks: function(): number, asMonths: function(): number, asYears: function(): number}}
  * @example
  * // Example usage:
  * const result = duration(1234, 'minute');
  * console.log(result);
- * // Output: { year: 0, month: 0, week: 0, day: 0, hour: 20, minute: 34, second: 0,millisecond: 0 }
+ * // Output: { years: 0, months: 0, weeks: 0, days: 0, hours: 20, minutes: 34, seconds: 0, milliseconds: 0 }
  */
 function duration(time, type) {
 	const _milliseconds = time * timeInMilliseconds[type];
 
 	const response = {
-		year: 0,
-		month: 0,
-		week: 0,
-		day: 0,
-		hour: 0,
-		minute: 0,
-		second: 0,
-		millisecond: 0,
+		years: 0,
+		months: 0,
+		weeks: 0,
+		days: 0,
+		hours: 0,
+		minutes: 0,
+		seconds: 0,
+		milliseconds: 0,
 		$kk_date: { milliseconds: 0 },
 		asMilliseconds: () => _milliseconds,
-		asSeconds: () => _milliseconds / timeInMilliseconds.second,
-		asMinutes: () => _milliseconds / timeInMilliseconds.minute,
-		asHours: () => _milliseconds / timeInMilliseconds.hour,
-		asDays: () => _milliseconds / timeInMilliseconds.day,
-		asWeeks: () => _milliseconds / timeInMilliseconds.week,
-		asMonths: () => _milliseconds / timeInMilliseconds.month,
-		asYears: () => _milliseconds / timeInMilliseconds.year,
+		asSeconds: () => _milliseconds / timeInMilliseconds.seconds,
+		asMinutes: () => _milliseconds / timeInMilliseconds.minutes,
+		asHours: () => _milliseconds / timeInMilliseconds.hours,
+		asDays: () => _milliseconds / timeInMilliseconds.days,
+		asWeeks: () => _milliseconds / timeInMilliseconds.weeks,
+		asMonths: () => _milliseconds / timeInMilliseconds.months,
+		asYears: () => _milliseconds / timeInMilliseconds.years,
 	};
 
 	if (!time || typeof time !== 'number' || time < 0) {
@@ -212,21 +212,21 @@ function duration(time, type) {
 
 	response.$kk_date.milliseconds = _milliseconds;
 	let milliseconds = _milliseconds;
-	response.year = Math.floor(milliseconds / timeInMilliseconds.year);
-	milliseconds = milliseconds % timeInMilliseconds.year;
-	response.month = Math.floor(milliseconds / timeInMilliseconds.month);
-	milliseconds = milliseconds % timeInMilliseconds.month;
-	response.week = Math.floor(milliseconds / timeInMilliseconds.week);
-	milliseconds = milliseconds % timeInMilliseconds.week;
-	response.day = Math.floor(milliseconds / timeInMilliseconds.day);
-	milliseconds = milliseconds % timeInMilliseconds.day;
-	response.hour = Math.floor(milliseconds / timeInMilliseconds.hour);
-	milliseconds = milliseconds % timeInMilliseconds.hour;
-	response.minute = Math.floor(milliseconds / timeInMilliseconds.minute);
-	milliseconds = milliseconds % timeInMilliseconds.minute;
-	response.second = Math.floor(milliseconds / timeInMilliseconds.second);
-	milliseconds = milliseconds % timeInMilliseconds.second;
-	response.millisecond = milliseconds;
+	response.years = Math.floor(milliseconds / timeInMilliseconds.years);
+	milliseconds = milliseconds % timeInMilliseconds.years;
+	response.months = Math.floor(milliseconds / timeInMilliseconds.months);
+	milliseconds = milliseconds % timeInMilliseconds.months;
+	response.weeks = Math.floor(milliseconds / timeInMilliseconds.weeks);
+	milliseconds = milliseconds % timeInMilliseconds.weeks;
+	response.days = Math.floor(milliseconds / timeInMilliseconds.days);
+	milliseconds = milliseconds % timeInMilliseconds.days;
+	response.hours = Math.floor(milliseconds / timeInMilliseconds.hours);
+	milliseconds = milliseconds % timeInMilliseconds.hours;
+	response.minutes = Math.floor(milliseconds / timeInMilliseconds.minutes);
+	milliseconds = milliseconds % timeInMilliseconds.minutes;
+	response.seconds = Math.floor(milliseconds / timeInMilliseconds.seconds);
+	milliseconds = milliseconds % timeInMilliseconds.seconds;
+	response.milliseconds = milliseconds;
 
 	return response;
 }

--- a/index.js
+++ b/index.js
@@ -458,19 +458,18 @@ class KkDate {
 		const starts = isKkDate(start) ? start.getTime() : new KkDate(start).getTime();
 		const ends = isKkDate(end) ? end.getTime() : new KkDate(end).getTime();
 		const date_time = this.date.getTime();
-		const unit_key = `${unit}s`;
 
 		if (unit === 'milliseconds') {
 			return date_time >= starts && date_time <= ends;
 		}
 
-		if (!timeInMilliseconds[unit_key]) {
+		if (!timeInMilliseconds[unit]) {
 			throw new Error('Invalid unit type. Must be one of: milliseconds, seconds, minutes, hours, days, months, years');
 		}
 
-		const startUnit = Math.floor(starts / timeInMilliseconds[unit_key]);
-		const endUnit = Math.floor(ends / timeInMilliseconds[unit_key]);
-		const dateUnit = Math.floor(date_time / timeInMilliseconds[unit_key]);
+		const startUnit = Math.floor(starts / timeInMilliseconds[unit]);
+		const endUnit = Math.floor(ends / timeInMilliseconds[unit]);
+		const dateUnit = Math.floor(date_time / timeInMilliseconds[unit]);
 
 		return dateUnit >= startUnit && dateUnit <= endUnit;
 	}
@@ -716,28 +715,28 @@ class KkDate {
 	/**
 	 * set method of Date instances changes
 	 *
-	 * @param {'second'|'minute'|'hour'|'day'|'month'|'year'} type - The unit of time type
+	 * @param {'seconds'|'minutes'|'hours'|'days'|'months'|'years'} type - The unit of time type
 	 * @param {number} value
 	 * @returns {KkDate}
 	 */
 	set(type, value) {
 		switch (type) {
-			case 'second':
+			case 'seconds':
 				this.date.setSeconds(value);
 				break;
-			case 'minute':
+			case 'minutes':
 				this.date.setMinutes(value);
 				break;
-			case 'hour':
+			case 'hours':
 				this.date.setHours(value);
 				break;
-			case 'day':
+			case 'days':
 				this.date.setDate(value);
 				break;
-			case 'month':
+			case 'months':
 				this.date.setMonth(value);
 				break;
-			case 'year':
+			case 'years':
 				this.date.setFullYear(value);
 				break;
 			default:
@@ -860,10 +859,10 @@ class KkDate {
 	/**
 	 * @description It divides the date string into parts and returns an object.
 	 * @param {string} time - time seconds
-	 * @returns {{year: number, month: number, week:number, day: number, hour: number, minute: number, second: number}}
+	 * @returns {{years: number, months: number, weeks: number, days: number, hours: number, minutes: number, seconds: number}}
 	 */
 	duration(time) {
-		return duration(time, 'second');
+		return duration(time, 'seconds');
 	}
 
 	/**
@@ -880,20 +879,20 @@ class KkDate {
 
 	/**
 	 * @description Returns startOf date of the unit of time.
-	 * @param {'year'|'month'|'week'|'day'|'hour'|'minute'|'second'} unit
+	 * @param {'years'|'months'|'weeks'|'days'|'hours'|'minutes'|'seconds'} unit
 	 * @returns {KkDate}
 	 */
 	startOf(unit) {
 		switch (unit) {
-			case 'year':
+			case 'years':
 				this.date.setMonth(0, 1);
 				this.date.setHours(0, 0, 0, 0);
 				break;
-			case 'month':
+			case 'months':
 				this.date.setDate(1);
 				this.date.setHours(0, 0, 0, 0);
 				break;
-			case 'week': {
+			case 'weeks': {
 				const dayOfWeek = this.date.getDay();
 				const weekStartDay = this.temp_config.weekStartDay || 0;
 				const diff = dayOfWeek < weekStartDay ? dayOfWeek + (7 - weekStartDay) : dayOfWeek - weekStartDay;
@@ -901,16 +900,16 @@ class KkDate {
 				this.date.setHours(0, 0, 0, 0);
 				break;
 			}
-			case 'day':
+			case 'days':
 				this.date.setHours(0, 0, 0, 0);
 				break;
-			case 'hour':
+			case 'hours':
 				this.date.setMinutes(0, 0, 0);
 				break;
-			case 'minute':
+			case 'minutes':
 				this.date.setSeconds(0, 0);
 				break;
-			case 'second':
+			case 'seconds':
 				this.date.setMilliseconds(0);
 				break;
 			default:
@@ -921,23 +920,23 @@ class KkDate {
 
 	/**
 	 * @description returns endOf date of the unit of time.
-	 * @param {'year'|'month'|'week'|'day'|'hour'|'minute'|'second'} unit
+	 * @param {'years'|'months'|'weeks'|'days'|'hours'|'minutes'|'seconds'} unit
 	 * @returns {KkDate}
 	 */
 	endOf(unit) {
 		switch (unit) {
-			case 'year':
+			case 'years':
 				this.date.setMonth(11, 31);
 				this.date.setHours(23, 59, 59, 999);
 				break;
-			case 'month': {
+			case 'months': {
 				const year = this.date.getFullYear();
 				const month = this.date.getMonth();
 				this.date.setDate(new Date(year, month + 1, 0).getDate());
 				this.date.setHours(23, 59, 59, 999);
 				break;
 			}
-			case 'week': {
+			case 'weeks': {
 				const dayOfWeek = this.date.getDay();
 				const weekStartDay = this.temp_config.weekStartDay || 0;
 				const diff = dayOfWeek < weekStartDay ? 7 - (weekStartDay - dayOfWeek) : 6 - (dayOfWeek - weekStartDay);
@@ -945,16 +944,16 @@ class KkDate {
 				this.date.setHours(23, 59, 59, 999);
 				break;
 			}
-			case 'day':
+			case 'days':
 				this.date.setHours(23, 59, 59, 999);
 				break;
-			case 'hour':
+			case 'hours':
 				this.date.setMinutes(59, 59, 999);
 				break;
-			case 'minute':
+			case 'minutes':
 				this.date.setSeconds(59, 999);
 				break;
-			case 'second':
+			case 'seconds':
 				this.date.setMilliseconds(999);
 				break;
 			default:
@@ -993,7 +992,7 @@ class KkDate {
 		}
 
 		let value;
-		let unit;
+		let unit; // ! READ: unit must be validate for .format !
 
 		// Determine the best unit to display
 		if (Math.abs(diffSeconds) < 45) {

--- a/test/other.test.js
+++ b/test/other.test.js
@@ -19,12 +19,12 @@ describe('kk_date diff', () => {
 });
 
 describe('kk_date set date', () => {
-	test('set day', () => {
-		expect(new kk_date(`${test_date} ${test_time}`).set('day', 20).set('year', '2025').isSame(`2025-08-20 ${test_time}`)).toBe(true);
+	test('set days', () => {
+		expect(new kk_date(`${test_date} ${test_time}`).set('days', 20).set('years', '2025').isSame(`2025-08-20 ${test_time}`)).toBe(true);
 	});
 
-	test('set year', () => {
-		expect(new kk_date(`${test_date} ${test_time}`).set('year', 2025).isSame(`2025-08-19 ${test_time}`)).toBe(true);
+	test('set years', () => {
+		expect(new kk_date(`${test_date} ${test_time}`).set('years', 2025).isSame(`2025-08-19 ${test_time}`)).toBe(true);
 	});
 });
 
@@ -32,54 +32,57 @@ describe('kk_date date checks', () => {
 	test('is between', () => {
 		expect(new kk_date(`${test_date} ${test_time}`).isBetween('2024-08-19', '2024-08-19 23:51')).toBe(true);
 	});
+	test('is between minutes', () => {
+		expect(new kk_date(`${test_date} ${test_time}`).isBetween('2024-08-19', '2024-08-19 23:51', 'minutes')).toBe(true);
+	});
 	test('is same', () => {
 		expect(new kk_date(`${test_date} ${test_time}`).isSame(`${test_date} ${test_time}`)).toBe(true);
 	});
 });
 
 describe('kk_date duration', () => {
-	test('duration year', () => {
-		const response = kk_date.duration(1, 'year');
-		expect(response.year).toBe(1);
-		expect(response.month).toBe(0);
-		expect(response.week).toBe(0);
-		expect(response.day).toBe(0);
-		expect(response.hour).toBe(0);
-		expect(response.minute).toBe(0);
-		expect(response.second).toBe(0);
+	test('duration years', () => {
+		const response = kk_date.duration(1, 'years');
+		expect(response.years).toBe(1);
+		expect(response.months).toBe(0);
+		expect(response.weeks).toBe(0);
+		expect(response.days).toBe(0);
+		expect(response.hours).toBe(0);
+		expect(response.minutes).toBe(0);
+		expect(response.seconds).toBe(0);
 	});
 
-	test('duration month', () => {
-		const response = kk_date.duration(65, 'day');
-		expect(response.year).toBe(0);
-		expect(response.month).toBe(2);
-		expect(response.week).toBe(0);
-		expect(response.day).toBe(3);
-		expect(response.hour).toBe(0);
-		expect(response.minute).toBe(0);
-		expect(response.second).toBe(0);
+	test('duration months', () => {
+		const response = kk_date.duration(65, 'days');
+		expect(response.years).toBe(0);
+		expect(response.months).toBe(2);
+		expect(response.weeks).toBe(0);
+		expect(response.days).toBe(3);
+		expect(response.hours).toBe(0);
+		expect(response.minutes).toBe(0);
+		expect(response.seconds).toBe(0);
 	});
 
-	test('duration day', () => {
-		const response = kk_date.duration(200, 'minute');
-		expect(response.year).toBe(0);
-		expect(response.month).toBe(0);
-		expect(response.week).toBe(0);
-		expect(response.day).toBe(0);
-		expect(response.hour).toBe(3);
-		expect(response.minute).toBe(20);
-		expect(response.second).toBe(0);
+	test('duration days', () => {
+		const response = kk_date.duration(200, 'minutes');
+		expect(response.years).toBe(0);
+		expect(response.months).toBe(0);
+		expect(response.weeks).toBe(0);
+		expect(response.days).toBe(0);
+		expect(response.hours).toBe(3);
+		expect(response.minutes).toBe(20);
+		expect(response.seconds).toBe(0);
 	});
 
-	test('duration minute', () => {
-		const response = kk_date.duration(50, 'minute');
-		expect(response.year).toBe(0);
-		expect(response.month).toBe(0);
-		expect(response.week).toBe(0);
-		expect(response.day).toBe(0);
-		expect(response.hour).toBe(0);
-		expect(response.minute).toBe(50);
-		expect(response.second).toBe(0);
+	test('duration minutes', () => {
+		const response = kk_date.duration(50, 'minutes');
+		expect(response.years).toBe(0);
+		expect(response.months).toBe(0);
+		expect(response.weeks).toBe(0);
+		expect(response.days).toBe(0);
+		expect(response.hours).toBe(0);
+		expect(response.minutes).toBe(50);
+		expect(response.seconds).toBe(0);
 	});
 });
 
@@ -87,36 +90,36 @@ describe('kk_date instance duration method', () => {
 	test('duration with timestamp', () => {
 		const date = new kk_date();
 		const response = date.duration(65); // 65 seconds
-		expect(response.year).toBe(0);
-		expect(response.month).toBe(0);
-		expect(response.week).toBe(0);
-		expect(response.day).toBe(0);
-		expect(response.hour).toBe(0);
-		expect(response.minute).toBe(1);
-		expect(response.second).toBe(5);
+		expect(response.years).toBe(0);
+		expect(response.months).toBe(0);
+		expect(response.weeks).toBe(0);
+		expect(response.days).toBe(0);
+		expect(response.hours).toBe(0);
+		expect(response.minutes).toBe(1);
+		expect(response.seconds).toBe(5);
 	});
 
 	test('duration with large timestamp', () => {
 		const date = new kk_date();
 		const response = date.duration(86400); // 1 day in seconds
-		expect(response.year).toBe(0);
-		expect(response.month).toBe(0);
-		expect(response.week).toBe(0);
-		expect(response.day).toBe(1);
-		expect(response.hour).toBe(0);
-		expect(response.minute).toBe(0);
-		expect(response.second).toBe(0);
+		expect(response.years).toBe(0);
+		expect(response.months).toBe(0);
+		expect(response.weeks).toBe(0);
+		expect(response.days).toBe(1);
+		expect(response.hours).toBe(0);
+		expect(response.minutes).toBe(0);
+		expect(response.seconds).toBe(0);
 	});
 
 	test('duration with complex timestamp', () => {
 		const date = new kk_date();
 		const response = date.duration(90061); // 1 day, 1 hour, 1 minute, 1 second
-		expect(response.year).toBe(0);
-		expect(response.month).toBe(0);
-		expect(response.week).toBe(0);
-		expect(response.day).toBe(1);
-		expect(response.hour).toBe(1);
-		expect(response.minute).toBe(1);
-		expect(response.second).toBe(1);
+		expect(response.years).toBe(0);
+		expect(response.months).toBe(0);
+		expect(response.weeks).toBe(0);
+		expect(response.days).toBe(1);
+		expect(response.hours).toBe(1);
+		expect(response.minutes).toBe(1);
+		expect(response.seconds).toBe(1);
 	});
 });

--- a/test/other.test.js
+++ b/test/other.test.js
@@ -32,7 +32,7 @@ describe('kk_date date checks', () => {
 	test('is between', () => {
 		expect(new kk_date(`${test_date} ${test_time}`).isBetween('2024-08-19', '2024-08-19 23:51')).toBe(true);
 	});
-	test('is between minutes', () => {
+	test('is between with minutes unit', () => {
 		expect(new kk_date(`${test_date} ${test_time}`).isBetween('2024-08-19', '2024-08-19 23:51', 'minutes')).toBe(true);
 	});
 	test('is same', () => {

--- a/test/startEndOf.test.js
+++ b/test/startEndOf.test.js
@@ -7,72 +7,72 @@ describe('kk_date startOf / endOf', () => {
 	const testEndOfMonthDateTime = '2024-03-31 12:00:00';
 
 	// --- startOf Tests ---
-	test('startOf year', () => {
-		expect(new kk_date(testDateTime).startOf('year').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-01-01 00:00:00');
+	test('startOf years', () => {
+		expect(new kk_date(testDateTime).startOf('years').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-01-01 00:00:00');
 	});
-	test('startOf month', () => {
-		expect(new kk_date(testDateTime).startOf('month').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-01 00:00:00');
+	test('startOf months', () => {
+		expect(new kk_date(testDateTime).startOf('months').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-01 00:00:00');
 	});
-	test('startOf week (assuming Sunday start)', () => {
+	test('startOf weeks (assuming Sunday start)', () => {
 		// 2024-08-19 is a Monday (day 1)
-		expect(new kk_date(testDateTime).startOf('week').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-18 00:00:00');
+		expect(new kk_date(testDateTime).startOf('weeks').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-18 00:00:00');
 		// Test with a Sunday
-		expect(new kk_date('2024-08-18 10:00:00').startOf('week').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-18 00:00:00');
+		expect(new kk_date('2024-08-18 10:00:00').startOf('weeks').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-18 00:00:00');
 	});
-	test('startOf day', () => {
-		expect(new kk_date(testDateTime).startOf('day').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 00:00:00');
+	test('startOf days', () => {
+		expect(new kk_date(testDateTime).startOf('days').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 00:00:00');
 	});
 	test('startOf hour', () => {
-		expect(new kk_date(testDateTime).startOf('hour').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:00:00');
+		expect(new kk_date(testDateTime).startOf('hours').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:00:00');
 	});
-	test('startOf minute', () => {
-		expect(new kk_date(testDateTime).startOf('minute').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:35:00');
+	test('startOf minutes', () => {
+		expect(new kk_date(testDateTime).startOf('minutes').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:35:00');
 	});
-	test('startOf second', () => {
-		expect(new kk_date(testDateTime).startOf('second').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:35:45');
+	test('startOf seconds', () => {
+		expect(new kk_date(testDateTime).startOf('seconds').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:35:45');
 	});
 
 	// --- endOf Tests ---
-	test('endOf year', () => {
-		expect(new kk_date(testDateTime).endOf('year').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-12-31 23:59:59');
+	test('endOf years', () => {
+		expect(new kk_date(testDateTime).endOf('years').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-12-31 23:59:59');
 	});
-	test('endOf month', () => {
-		expect(new kk_date(testDateTime).endOf('month').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-31 23:59:59');
+	test('endOf months', () => {
+		expect(new kk_date(testDateTime).endOf('months').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-31 23:59:59');
 		// Test leap year February
-		expect(new kk_date(testLeapDateTime).endOf('month').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-02-29 23:59:59');
+		expect(new kk_date(testLeapDateTime).endOf('months').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-02-29 23:59:59');
 		// Test non-leap year February
-		expect(new kk_date('2025-02-10').endOf('month').format('YYYY-MM-DD HH:mm:ss')).toBe('2025-02-28 23:59:59');
+		expect(new kk_date('2025-02-10').endOf('months').format('YYYY-MM-DD HH:mm:ss')).toBe('2025-02-28 23:59:59');
 		// Test 30-day month
-		expect(new kk_date('2024-04-15').endOf('month').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-04-30 23:59:59');
+		expect(new kk_date('2024-04-15').endOf('months').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-04-30 23:59:59');
 		// Test 31-day month
-		expect(new kk_date(testEndOfMonthDateTime).endOf('month').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-03-31 23:59:59');
+		expect(new kk_date(testEndOfMonthDateTime).endOf('months').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-03-31 23:59:59');
 	});
-	test('endOf week (assuming Saturday end)', () => {
+	test('endOf weeks (assuming Saturday end)', () => {
 		// 2024-08-19 is a Monday (day 1)
-		expect(new kk_date(testDateTime).endOf('week').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-24 23:59:59');
+		expect(new kk_date(testDateTime).endOf('weeks').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-24 23:59:59');
 		// Test with a Saturday
-		expect(new kk_date('2024-08-24 10:00:00').endOf('week').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-24 23:59:59');
+		expect(new kk_date('2024-08-24 10:00:00').endOf('weeks').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-24 23:59:59');
 	});
-	test('endOf day', () => {
-		expect(new kk_date(testDateTime).endOf('day').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 23:59:59');
+	test('endOf days', () => {
+		expect(new kk_date(testDateTime).endOf('days').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 23:59:59');
 	});
-	test('endOf hour', () => {
-		expect(new kk_date(testDateTime).endOf('hour').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:59:59');
+	test('endOf hours', () => {
+		expect(new kk_date(testDateTime).endOf('hours').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:59:59');
 	});
 	test('endOf minute', () => {
-		expect(new kk_date(testDateTime).endOf('minute').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:35:59');
+		expect(new kk_date(testDateTime).endOf('minutes').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:35:59');
 	});
-	test('endOf second', () => {
-		expect(new kk_date(testDateTime).endOf('second').format('HH:mm:ss.SSS')).toBe('14:35:45.999');
+	test('endOf seconds', () => {
+		expect(new kk_date(testDateTime).endOf('seconds').format('HH:mm:ss.SSS')).toBe('14:35:45.999');
 	});
 
 	test('startOf/endOf chaining', () => {
-		expect(new kk_date(testDateTime).startOf('day').add(12, 'hours').format('HH:mm')).toBe('12:00');
-		expect(new kk_date(testDateTime).endOf('month').startOf('day').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-31 00:00:00');
+		expect(new kk_date(testDateTime).startOf('days').add(12, 'hours').format('HH:mm')).toBe('12:00');
+		expect(new kk_date(testDateTime).endOf('months').startOf('days').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-31 00:00:00');
 	});
 
 	test('startOf/endOf invalid unit', () => {
-		expect(() => new kk_date(testDateTime).startOf('years')).toThrow('Invalid unit for startOf: years');
-		expect(() => new kk_date(testDateTime).endOf('days')).toThrow('Invalid unit for endOf: days');
+		expect(() => new kk_date(testDateTime).startOf('year')).toThrow('Invalid unit for startOf: year');
+		expect(() => new kk_date(testDateTime).endOf('day')).toThrow('Invalid unit for endOf: day');
 	});
 });

--- a/test/startEndOf.test.js
+++ b/test/startEndOf.test.js
@@ -59,7 +59,7 @@ describe('kk_date startOf / endOf', () => {
 	test('endOf hours', () => {
 		expect(new kk_date(testDateTime).endOf('hours').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:59:59');
 	});
-	test('endOf minute', () => {
+	test('endOf minutes', () => {
 		expect(new kk_date(testDateTime).endOf('minutes').format('YYYY-MM-DD HH:mm:ss')).toBe('2024-08-19 14:35:59');
 	});
 	test('endOf seconds', () => {

--- a/test/validInvalid.test.js
+++ b/test/validInvalid.test.js
@@ -45,7 +45,7 @@ describe('kk_date valid / invalid', () => {
 	});
 
 	test('duration invalid type', () => {
-		expect(() => kk_date.duration(10, 'days')).toThrow('Invalid type');
+		expect(() => kk_date.duration(10, 'day')).toThrow('Invalid type');
 		expect(() => kk_date.duration(10, '')).toThrow('Invalid type');
 		expect(() => kk_date.duration(10)).toThrow('Invalid type');
 	});

--- a/test/weekStartDay.test.js
+++ b/test/weekStartDay.test.js
@@ -2,73 +2,73 @@ const { describe, test, expect } = require('@jest/globals');
 const kk_date = require('../index');
 
 describe('weekStartDay tests for startOf and endOf', () => {
-    test('should return Sunday as startOf and Saturday as endOf when weekStartDay is 0', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: 0 });
-        expect(date.startOf('week').format('dddd')).toBe('Sunday');
-        expect(date.endOf('week').format('dddd')).toBe('Saturday');
-    });
+	test('should return Sunday as startOf and Saturday as endOf when weekStartDay is 0', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: 0 });
+		expect(date.startOf('weeks').format('dddd')).toBe('Sunday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Saturday');
+	});
 
-    test('should return Monday as startOf and Sunday as endOf when weekStartDay is 1', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: 1 });
-        expect(date.startOf('week').format('dddd')).toBe('Monday');
-        expect(date.endOf('week').format('dddd')).toBe('Sunday');
-    });
+	test('should return Monday as startOf and Sunday as endOf when weekStartDay is 1', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: 1 });
+		expect(date.startOf('weeks').format('dddd')).toBe('Monday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Sunday');
+	});
 
-    test('should return Tuesday as startOf and Monday as endOf when weekStartDay is 2', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: 2 });
-        expect(date.startOf('week').format('dddd')).toBe('Tuesday');
-        expect(date.endOf('week').format('dddd')).toBe('Monday');
-    });
+	test('should return Tuesday as startOf and Monday as endOf when weekStartDay is 2', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: 2 });
+		expect(date.startOf('weeks').format('dddd')).toBe('Tuesday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Monday');
+	});
 
-    test('should return Wednesday as startOf and Tuesday as endOf when weekStartDay is 3', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: 3 });
-        expect(date.startOf('week').format('dddd')).toBe('Wednesday');
-        expect(date.endOf('week').format('dddd')).toBe('Tuesday');
-    });
+	test('should return Wednesday as startOf and Tuesday as endOf when weekStartDay is 3', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: 3 });
+		expect(date.startOf('weeks').format('dddd')).toBe('Wednesday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Tuesday');
+	});
 
-    test('should return Thursday as startOf and Wednesday as endOf when weekStartDay is 4', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: 4 });
-        expect(date.startOf('week').format('dddd')).toBe('Thursday');
-        expect(date.endOf('week').format('dddd')).toBe('Wednesday');
-    });
+	test('should return Thursday as startOf and Wednesday as endOf when weekStartDay is 4', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: 4 });
+		expect(date.startOf('weeks').format('dddd')).toBe('Thursday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Wednesday');
+	});
 
-    test('should return Friday as startOf and Thursday as endOf when weekStartDay is 5', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: 5 });
-        expect(date.startOf('week').format('dddd')).toBe('Friday');
-        expect(date.endOf('week').format('dddd')).toBe('Thursday');
-    });
+	test('should return Friday as startOf and Thursday as endOf when weekStartDay is 5', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: 5 });
+		expect(date.startOf('weeks').format('dddd')).toBe('Friday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Thursday');
+	});
 
-    test('should return Saturday as startOf and Friday as endOf when weekStartDay is 6', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: 6 });
-        expect(date.startOf('week').format('dddd')).toBe('Saturday');
-        expect(date.endOf('week').format('dddd')).toBe('Friday');
-    });
+	test('should return Saturday as startOf and Friday as endOf when weekStartDay is 6', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: 6 });
+		expect(date.startOf('weeks').format('dddd')).toBe('Saturday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Friday');
+	});
 
-    test('should return Sunday as startOf and Saturday as endOf when weekStartDay is a string', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: 'test' }); 
-        expect(date.startOf('week').format('dddd')).toBe('Sunday');
-        expect(date.endOf('week').format('dddd')).toBe('Saturday');
-    });
+	test('should return Sunday as startOf and Saturday as endOf when weekStartDay is a string', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: 'test' });
+		expect(date.startOf('weeks').format('dddd')).toBe('Sunday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Saturday');
+	});
 
-    test('should return Sunday as startOf and Saturday as endOf when weekStartDay is negative', () => {
-        const date = new kk_date();
-        date.config({ weekStartDay: -1 }); 
-        expect(date.startOf('week').format('dddd')).toBe('Sunday');
-        expect(date.endOf('week').format('dddd')).toBe('Saturday');
-    });
+	test('should return Sunday as startOf and Saturday as endOf when weekStartDay is negative', () => {
+		const date = new kk_date();
+		date.config({ weekStartDay: -1 });
+		expect(date.startOf('weeks').format('dddd')).toBe('Sunday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Saturday');
+	});
 
-    test('should default to Sunday as startOf and Saturday as endOf when weekStartDay is not provided', () => {
-        const date = new kk_date();
-        date.config({});
-        expect(date.startOf('week').format('dddd')).toBe('Sunday');
-        expect(date.endOf('week').format('dddd')).toBe('Saturday');
-    });
+	test('should default to Sunday as startOf and Saturday as endOf when weekStartDay is not provided', () => {
+		const date = new kk_date();
+		date.config({});
+		expect(date.startOf('weeks').format('dddd')).toBe('Sunday');
+		expect(date.endOf('weeks').format('dddd')).toBe('Saturday');
+	});
 });


### PR DESCRIPTION
Breaking changes have been made to the following functions: **isBetween, set, duration, startOf, and endOf**.
All time unit parameters have been renamed from singular to plural form (e.g., day → days, month → months). Tests have been updated accordingly.

Additionally, isBetween no longer throws an error when using time units other than milliseconds. Tests have been updated accordingly.