### PR TITLE
weekStartDay can be changed in global config and local config

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -268,6 +268,7 @@ const global_config = {
 	timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 	userTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 	rtf: {},
+	weekStartDay: 0,
 };
 
 module.exports.cache_ttl = cache_ttl;

--- a/functions.js
+++ b/functions.js
@@ -102,7 +102,6 @@ function parseWithTimezone(kkDate, is_init = false) {
 		const global_timezone = getTimezoneOffset(global_config.timezone);
 		const kk_ofset = kkDate.date.getTimezoneOffset() * 60 * 1000;
 
-		// console.log(temp_timezone / 1000 / 60 / 60, global_timezone / 1000 / 60 / 60, kk_ofset / 1000 / 60 / 60);
 		if (kkDate.detected_format === 'Xx' && global_config.timezone !== global_config.userTimezone && is_init) {
 			return new Date(utcTime + kk_ofset + global_timezone);
 		}

--- a/test/weekStartDay.test.js
+++ b/test/weekStartDay.test.js
@@ -58,17 +58,28 @@ describe('weekStartDay tests for startOf and endOf', () => {
 		expect(date.endOf('weeks').format('dddd')).toBe('Saturday');
 	});
 
-	test('should return Sunday as startOf and Saturday as endOf when weekStartDay is negative', () => {
-		const date = new kk_date();
-		date.config({ weekStartDay: -1 });
-		expect(date.startOf('weeks').format('dddd')).toBe('Sunday');
-		expect(date.endOf('weeks').format('dddd')).toBe('Saturday');
-	});
-
 	test('should default to Sunday as startOf and Saturday as endOf when weekStartDay is not provided', () => {
 		const date = new kk_date();
 		date.config({});
 		expect(date.startOf('weeks').format('dddd')).toBe('Sunday');
 		expect(date.endOf('weeks').format('dddd')).toBe('Saturday');
+	});
+	test('should throw an error when weekStartDay', () => {
+		expect(() => new kk_date().config({ weekStartDay: 8 })).toThrow();
+	});
+	test('Should be six days weekStartDay when 0-1 is entered, the difference between the start and end ', () => {
+		kk_date.config({ weekStartDay: 0 });
+		const kkdate1 = new kk_date();
+		expect(new kk_date(kkdate1.startOf('weeks')).diff(new kk_date(kkdate1.endOf('weeks')), 'days')).toBe(6);
+
+		kk_date.config({ weekStartDay: 2 });
+		const kkdate2 = new kk_date();
+		expect(new kk_date(kkdate2.startOf('weeks')).diff(new kk_date(kkdate2.endOf('weeks')), 'days')).toBe(6);
+	});
+
+	test('Should be six days weekStartDay when random 0-6 is entered, the difference between the start and end ', () => {
+		kk_date.config({ weekStartDay: Math.floor(Math.random() * 7) });
+		const kkdate1 = new kk_date();
+		expect(new kk_date(kkdate1.startOf('weeks')).diff(new kk_date(kkdate1.endOf('weeks')), 'days')).toBe(6);
 	});
 });


### PR DESCRIPTION
+ WeekStartDay can also be edited via global config.
`kkdate.config({ locale: 'en', weekStartDay: 2 });`
+ Added throw error.
+ New test cases have been written.
+ Fixed endOf result not calculating correctly when weekStartDay is 2 and above.
