### PR TITLE
Improvements and fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 26
       - name: Update Version
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 26
           cache: 'npm'
       - name: Install packages
         run: npm ci
@@ -28,9 +28,15 @@ jobs:
         run: npm run lint
 
   unit-tests:
-    name: Unit tests
+    name: Unit tests (Node ${{ matrix.node-version }})
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Supported range: Node 22+. (Node 20/21 have a known date-arithmetic
+        # incompatibility; Node <18 cannot run the Jest 30 test runner.)
+        node-version: [22, 24, 26]
     steps:
       - name: Check Out Repository
         uses: actions/checkout@v4
@@ -39,7 +45,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install packages
         run: npm ci
@@ -81,7 +87,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 26
           cache: 'npm'
       - name: Install packages
         run: npm ci
@@ -102,7 +108,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 26
           cache: 'npm'
       - name: Install packages
         run: npm ci
@@ -127,7 +133,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 26
           cache: 'npm'
       - name: Install packages
         run: npm ci

--- a/.github/workflows/update-benchmarks.yml
+++ b/.github/workflows/update-benchmarks.yml
@@ -1,0 +1,89 @@
+name: Update Benchmark Docs
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [opened, synchronize, reopened]
+  # Manual rerun from the Actions tab. When dispatched manually we benchmark the
+  # chosen ref but do NOT commit back (the numbers are left as an artifact).
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch/tag/SHA to benchmark (defaults to the branch the workflow runs from)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+concurrency:
+  group: bench-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    # Skip fork PRs on pull_request runs (the default token cannot push back to a fork).
+    # Manual workflow_dispatch runs always proceed.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          # pull_request: check out the PR branch so the refreshed docs can be pushed back.
+          # workflow_dispatch: check out the supplied ref (defaults to the branch the dispatch ran from).
+          ref: ${{ github.event.pull_request.head.ref || inputs.ref || github.ref_name }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install packages
+        run: npm ci
+
+      # Gate the benchmark on a green test run: if tests fail, the workflow stops
+      # before benchmarking, so the docs are never refreshed from a broken build.
+      - name: Run tests
+        run: npm test
+
+      # All tests passed: produce fresh JSON benchmark numbers.
+      - name: Run benchmarks (JSON)
+        run: |
+          node benchmark2.js --json > bench-sequential.json
+          node benchmark.js --json > bench-comprehensive.json
+
+      - name: Upload benchmark JSON artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: |
+            bench-sequential.json
+            bench-comprehensive.json
+          retention-days: 30
+
+      - name: Refresh performance tables in README.md + docs/PERFORMANCE.md
+        run: node scripts/update-benchmark-docs.js bench-comprehensive.json bench-sequential.json
+
+      - name: Commit refreshed docs
+        # Only push the refresh back on PR events. Manual dispatch leaves the artifacts
+        # for the operator to inspect without mutating any branch.
+        if: github.event_name == 'pull_request'
+        run: |
+          git add README.md docs/PERFORMANCE.md
+          if git diff --cached --quiet; then
+            echo "No benchmark changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # The ci-skip marker is built by concatenation so this auto-commit does not
+          # re-trigger the workflow (and so this file itself contains no literal directive).
+          MARKER="[skip"" ci]"
+          git commit -m "chore(bench): refresh performance numbers $MARKER"
+          git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/update-benchmarks.yml
+++ b/.github/workflows/update-benchmarks.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 26
           cache: 'npm'
 
       - name: Install packages

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,8 @@ dist
 yarn.lock
 .DS_Store
 CLAUDE.md
+
+# Benchmark JSON output (produced by `benchmark*.js --json`; consumed by the Update Benchmark Docs workflow)
+bench-sequential.json
+bench-comprehensive.json
+bench.json

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 [![npm version](https://badge.fury.io/js/kk-date.svg)](https://badge.fury.io/js/kk-date)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/Tests-322%20passed-brightgreen)](https://github.com/kentkartlab/kk-date)
+[![Tests](https://img.shields.io/badge/Tests-499%20passed-brightgreen)](https://github.com/kentkartlab/kk-date)
 
 A blazing-fast JavaScript date library with intelligent caching, automatic DST detection, and zero-config timezone handling. Perfect for high-performance applications, real-time systems, and data-intensive operations where speed and accuracy matter most.
 
 ## 🌟 Why Choose kk-date?
 
-### Performance & Efficiency
-- **⚡ Lightning Fast** - Up to 43x faster timezone operations than Day.js
-- **🚀 84.58% Faster Overall** - Outperforms Moment.js, Day.js, and Luxon in comprehensive benchmarks
-- **💾 Memory Efficient** - Negative memory usage (-7.39 MB) through aggressive optimization
-- **⚙️ Smart Caching** - 74.55% performance boost with built-in caching system
+### Performance & Efficiency *(measured on Node.js 22; reproduced by CI, results vary)*
+- **⚡ Lightning Fast** - Over 40x faster timezone operations than Day.js
+- **🚀 ~80% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")
+- **💾 Memory Efficient** - Object pooling + LRU cache eviction keep long-running processes stable
+- **⚙️ Smart Caching** - ~70% faster repeated operations with built-in caching
 
 ### Reliability & Safety
 - **🛡️ Fail-Fast Design** - Invalid dates immediately throw errors, preventing silent bugs in production
 - **🎯 Type Safety** - Rejects malformed dates instead of returning unexpected results
 - **✅ Predictable Behavior** - Never continues with invalid dates, unlike libraries that return "Invalid Date"
-- **🔒 Production Tested** - 322 comprehensive tests covering edge cases and DST transitions
+- **🔒 Production Tested** - 499 comprehensive tests covering edge cases and DST transitions
 
 ### Features & Compatibility
 - **🌍 Accurate Timezone Handling** - 95-99% faster timezone conversions with perfect accuracy
@@ -51,21 +51,23 @@ try {
     console.log('Invalid date prevented!'); // ✅ Error caught, no silent bugs
 }
 
-// Pre-validate dates without throwing errors
-if (kk_date.isValid('2024-13-45')) { // false - invalid month
+// Pre-validate dates without throwing errors (the static isValid() requires a format template)
+if (kk_date.isValid('2024-13-45', 'YYYY-MM-DD')) { // false - invalid month
     // Won't execute
 }
-if (kk_date.isValid('2024-08-23')) { // true - valid date
+if (kk_date.isValid('2024-08-23', 'YYYY-MM-DD')) { // true - valid date
     const safeDate = new kk_date('2024-08-23'); // ✅ Safe to create
 }
 
-// Zero-config timezone conversion with automatic DST detection
+// Zero-config timezone conversion with automatic DST detection.
+// Note: a naive string like '2024-08-23 10:30:00' is parsed in the process's LOCAL timezone.
+// The examples below assume the process timezone is UTC (run with TZ=UTC, or call
+// kk_date.setTimezone('UTC')). Pass an absolute instant ('...Z') for identical results everywhere.
 const nyTime = new kk_date('2024-08-23 10:30:00').tz('America/New_York');
 console.log(nyTime.format('HH:mm')); // 06:30 (EDT - automatically detected)
 
-// Consistent results across all platforms and systems
 const tokyoTime = new kk_date('2024-08-23 10:30:00').tz('Asia/Tokyo');
-console.log(tokyoTime.format('HH:mm')); // 16:00 (JST - consistent everywhere)
+console.log(tokyoTime.format('HH:mm')); // 19:30 (JST)
 
 // Lightning-fast date manipulation
 const tomorrow = new kk_date('2024-08-23 10:30:00').add(1, 'days');
@@ -116,25 +118,27 @@ Timezone handling is one of the most critical aspects of date libraries. Inconsi
 ### Real-World Example
 
 ```javascript
-// Test date: 2024-08-23 10:00:00 (local time)
-const testDate = '2024-08-23 10:00:00';
+// Test instant: an absolute UTC instant (ISO-8601 with 'Z') is unambiguous on every machine.
+// (A naive string like '2024-08-23 10:00:00' would instead be parsed in the process's local
+// timezone, so pass an absolute instant when you need identical results everywhere.)
+const testDate = '2024-08-23T10:00:00.000Z';
 
-// kk-date: Consistent results across all platforms
+// kk-date: absolute instant converts to the same wall-clock on every system
 const kkDate = new kk_date(testDate).tz('America/New_York');
 console.log(kkDate.format('YYYY-MM-DD HH:mm:ss'));
-// Result: 2024-08-23 06:00:00 (consistent everywhere)
+// Result: 2024-08-23 06:00:00 (identical on every system)
 
-// Moment.js: Results vary based on system timezone
+// Moment.js: requires the moment-timezone add-on for .tz()
 const moment = require('moment-timezone');
 const momentDate = moment(testDate);
 console.log(momentDate.tz('America/New_York').format('YYYY-MM-DD HH:mm:ss'));
-// Result: Varies by system timezone (inconsistent!)
+// Result: 2024-08-23 06:00:00 (needs moment-timezone)
 
-// Day.js: Same inconsistency as Moment.js
+// Day.js: requires the utc + timezone plugins for .tz()
 const dayjs = require('dayjs');
 const dayjsDate = dayjs(testDate);
 console.log(dayjsDate.tz('America/New_York').format('YYYY-MM-DD HH:mm:ss'));
-// Result: Varies by system timezone (inconsistent!)
+// Result: 2024-08-23 06:00:00 (needs dayjs timezone plugin)
 ```
 
 ### Cross-Platform Consistency
@@ -142,14 +146,15 @@ console.log(dayjsDate.tz('America/New_York').format('YYYY-MM-DD HH:mm:ss'));
 **kk-date** provides **identical results** across different systems:
 
 ```javascript
-// Same code, same results on Windows, macOS, Linux, and Docker
-const baseTime = '2024-08-23 10:00:00';
+// Same code, same results on Windows, macOS, Linux, and Docker.
+// Use an absolute instant (ISO-8601 with 'Z') so the value does not depend on the system timezone.
+const baseTime = '2024-08-23T10:00:00.000Z';
 
 // These results are identical on all platforms:
-console.log(new kk_date(baseTime).tz('UTC').format('YYYY-MM-DD HH:mm:ss'));        // 2024-08-23 07:00:00
-console.log(new kk_date(baseTime).tz('America/New_York').format('YYYY-MM-DD HH:mm:ss')); // 2024-08-23 03:00:00
-console.log(new kk_date(baseTime).tz('Europe/London').format('YYYY-MM-DD HH:mm:ss'));    // 2024-08-23 08:00:00
-console.log(new kk_date(baseTime).tz('Asia/Tokyo').format('YYYY-MM-DD HH:mm:ss'));       // 2024-08-23 16:00:00
+console.log(new kk_date(baseTime).tz('UTC').format('YYYY-MM-DD HH:mm:ss'));        // 2024-08-23 10:00:00
+console.log(new kk_date(baseTime).tz('America/New_York').format('YYYY-MM-DD HH:mm:ss')); // 2024-08-23 06:00:00
+console.log(new kk_date(baseTime).tz('Europe/London').format('YYYY-MM-DD HH:mm:ss'));    // 2024-08-23 11:00:00
+console.log(new kk_date(baseTime).tz('Asia/Tokyo').format('YYYY-MM-DD HH:mm:ss'));       // 2024-08-23 19:00:00
 ```
 
 ### Automatic DST Detection
@@ -157,15 +162,16 @@ console.log(new kk_date(baseTime).tz('Asia/Tokyo').format('YYYY-MM-DD HH:mm:ss')
 **kk-date** automatically handles Daylight Saving Time transitions:
 
 ```javascript
-// DST transition dates - kk-date handles automatically
-const dstStart = new kk_date('2024-03-10 02:30:00'); // DST begins
-const dstEnd = new kk_date('2024-11-03 02:30:00');   // DST ends
+// DST transition dates - kk-date handles automatically.
+// (Naive inputs below assume the process timezone is UTC; see the note above.)
+const dstStart = new kk_date('2024-03-10 02:30:00'); // near DST start
+const dstEnd = new kk_date('2024-11-03 02:30:00');   // near DST end
 
 console.log(new kk_date('2024-03-10 02:30:00').tz('America/New_York').format('YYYY-MM-DD HH:mm:ss'));
-// Result: 2024-03-09 21:30:00 (correctly adjusted)
+// Result: 2024-03-09 21:30:00 (EST, correctly adjusted)
 
 console.log(new kk_date('2024-11-03 02:30:00').tz('America/New_York').format('YYYY-MM-DD HH:mm:ss'));
-// Result: 2024-11-02 21:30:00 (correctly adjusted)
+// Result: 2024-11-02 22:30:00 (EDT, correctly adjusted)
 ```
 
 ### Safety Comparison: kk-date vs Others
@@ -203,7 +209,7 @@ try {
 
 ## 🎯 Performance & Reliability
 
-### 🚀 Intelligent Caching System (74.55% Performance Boost!)
+### 🚀 Intelligent Caching System (~70% Performance Boost)
 
 ```javascript
 // Enable high-performance caching for massive speed improvements
@@ -220,7 +226,7 @@ const stats = kk_date.caching_status();
 const hitRate = stats.totalHits > 0 ? (stats.totalHits / (stats.totalHits + stats.total) * 100).toFixed(1) : 0;
 console.log('Cache hit rate:', hitRate + '%'); // Typically 99%+
 console.log('Cache size:', stats.cacheSize + '/' + stats.maxCacheSize); // Current/Max
-console.log('Performance gain:', '74.55%'); // Measured improvement
+console.log('Performance gain:', '~70%'); // Representative measured improvement (varies)
 
 // Handle millions of operations efficiently
 for (let i = 0; i < 1000000; i++) {
@@ -282,7 +288,9 @@ const date2 = new kk_date('2024-08-25');
 date1.isBefore(date2);                  // true
 date1.isAfter(date2);                   // false
 date1.isSame(date2);                    // false
-date1.diff(date2, 'days');              // -2
+// diff is measured as (other - this), so a later argument yields a positive result:
+date1.diff(date2, 'days');              // 2
+date2.diff(date1, 'days');              // -2
 ```
 
 ## 🔧 Configuration
@@ -368,6 +376,8 @@ console.log(date.format('DD/MM/YYYY')); // 23/08/2024
 
 ## 📊 Performance Benchmarks
 
+> **Note:** All performance figures in this README come from our own benchmark suite on Node.js 22 and are **reproduced by CI on every PR** (the "Performance Benchmarks" job runs `benchmark.js` + `benchmark2.js` and uploads the results). They are **not guarantees** — results vary by workload, hardware, Node version, and caching. Reproduce locally with `node benchmark.js` / `node benchmark2.js`. kk-date wins most scenarios but not all (e.g. Day.js is faster in isolated "Time Operations").
+
 ### Real-World Sequential Operations (1000 days, 100 operations/day)
 
 Our benchmark simulates real-world usage by processing 1000 sequential days with 100 operations per day. This reflects typical production scenarios where dates are processed in sequence rather than synthetic benchmarks.
@@ -377,63 +387,63 @@ Our benchmark simulates real-world usage by processing 1000 sequential days with
 node benchmark2.js
 ```
 
-**Latest Results (December 2024):**
+**Representative run (Node.js 22) — reproduced by CI on every PR (see the "Performance Benchmarks" job artifacts). Numbers vary run-to-run.** Totals are for 100,000 operations per scenario:
 
-| Operation | kk-date | Moment.js | Day.js | Luxon | Speed vs Fastest Competitor |
-|-----------|---------|-----------|--------|-------|-----------------------------|
-| **Date Creation & Formatting** | **284ms** | 633ms | 464ms | 564ms | **63% faster** than Day.js |
-| **Time Operations** | **201ms** | 786ms | 399ms | 2196ms | **98% faster** than Day.js |
-| **Timezone Conversions** | **338ms** | 1231ms | 14806ms | 2836ms | **264% faster** than Moment |
-| **Complex Operations** | **477ms** | 1469ms | 905ms | 2513ms | **90% faster** than Day.js |
+<!-- BENCH:readme-seq -->
+| Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
+|-----------|---------|-----------|--------|-------|-----------------------|
+| **Date Creation & Formatting** | **284ms** | 667ms | 487ms | 627ms | **~72% faster** than Day.js |
+| **Time Operations** | 439ms | 754ms | **357ms** | 1580ms | **~23% slower** than Day.js |
+| **Timezone Conversions** | **304ms** | 1085ms | 12586ms | 2314ms | **~257% faster** than Moment |
+| **Complex Operations** | **524ms** | 1318ms | 825ms | 1768ms | **~57% faster** than Day.js |
+<!-- /BENCH:readme-seq -->
 
 ### Overall Performance Summary
 
+kk-date wins the overall sequential run, though Day.js is faster in the isolated "Time Operations" scenario above.
+
+<!-- BENCH:readme-overall -->
 | Library | Total Time | Operations/sec | Performance |
 |---------|------------|---------------|-------------|
-| **kk-date** | **1.30s** | **307,608 ops/sec** | 🏆 **Winner** |
-| Moment.js | 4.12s | 97,095 ops/sec | 217% slower |
-| Luxon | 8.11s | 49,328 ops/sec | 524% slower |
-| Day.js | 16.57s | 24,134 ops/sec | **1175% slower** |
+| **kk-date** | **1.55s** | **257,958 ops/sec** | 🏆 **Winner** |
+| Moment.js | 3.82s | 104,629 ops/sec | ~147% slower |
+| Luxon | 6.29s | 63,598 ops/sec | ~306% slower |
+| Day.js | 14.25s | 28,062 ops/sec | **~819% slower** |
+<!-- /BENCH:readme-overall -->
 
-### Memory Efficiency
+### Memory & Bundle Size
 
-| Library | Memory Usage | Bundle Size | DST Support |
-|---------|-------------|-------------|-------------|
-| **kk-date** | **-7.39 MB** ⚡ | **15 KB** | **Built-in** |
-| Moment.js | ~180 MB | 297 KB | Plugin required |
-| Day.js | ~175 MB | 18.5 KB | Plugin required |
-| Luxon | ~178 MB | 71 KB | Built-in |
+Net heap delta after creating 100,000 date instances (from `node benchmark.js`). This metric is **dominated by GC timing**, so it is noisy and several libraries can show a *negative* net delta — it is not a unique kk-date property. Bundle sizes are the published package sizes.
 
-#### Why "Negative" Memory Usage? 🤔
+<!-- BENCH:readme-memory -->
+| Library | Heap Δ / 100k instances* | Bundle Size | DST Support |
+|---------|--------------------------|-------------|-------------|
+| **kk-date** | ~+4 MB | **15 KB** | **Built-in** |
+| Moment.js | ~-3 MB* | 297 KB | Plugin required |
+| Day.js | ~0 MB | 18.5 KB | Plugin required |
+| Luxon | ~+4 MB | 71 KB | Built-in |
+<!-- /BENCH:readme-memory -->
 
-The **-7.39 MB** negative memory usage is a remarkable achievement showing our superior memory management:
+<sub>* GC-timing artifact — varies run-to-run and can be negative for multiple libraries; reproduce with `node benchmark.js`.</sub>
 
-**How it works:**
-1. **Object Pooling**: kk-date reuses existing objects instead of creating new ones
-2. **Aggressive Garbage Collection**: Our efficient patterns trigger V8's garbage collector
-3. **Memory Cleanup**: During operations, we actually clean up more memory than we use
-4. **Smart Caching**: LRU cache with automatic eviction prevents memory bloat
-
-**What this means for your application:**
-- ✅ **No memory leaks** - Memory usage decreases over time
-- ✅ **Perfect for long-running apps** - Memory doesn't accumulate
-- ✅ **Lower server costs** - Less RAM needed for the same workload
-- ✅ **Better performance** - Less garbage collection pressure
+kk-date's real memory advantages come from **object pooling**, **LRU cache eviction**, and creating few intermediate objects — which keep long-running processes stable. The exact heap-delta number is not a guarantee.
 
 ```javascript
 // Measurement methodology:
 const before = process.memoryUsage().heapUsed;
 // Create 100,000 date instances...
 const after = process.memoryUsage().heapUsed;
-// Result: after < before (negative difference!)
+console.log((after - before) / 1024 / 1024, 'MB'); // GC-dependent; can be negative
 ```
 
 ### Cache Performance Impact
 
-**Without Cache vs With Cache:**
-- **74.55% performance improvement** when cache is enabled
-- Average operation time: 77ms → 20ms with cache
+**Without Cache vs With Cache (representative run):**
+<!-- BENCH:readme-cache -->
+- **~69% faster** repeated operations when cache is enabled
+- Average operation time: ~67ms → ~21ms with cache
 - Cache hit ratio: **100%** for repeated operations
+<!-- /BENCH:readme-cache -->
 - Memory overhead: Minimal (< 10MB for 10,000 cached items)
 
 **Why Enable Caching:**
@@ -450,13 +460,13 @@ kk_date.caching({ status: true, defaultTtl: 3600 });
 
 ### Key Performance Advantages
 
-- **⚡ 84.58% faster** than the average of competing libraries
+- **⚡ ~80% faster** than the average of competing libraries (comprehensive benchmark)
 - **🚀 95-99% faster** in timezone operations (critical for global apps)
-- **📊 95.13% faster** for Big Data operations (1M date operations)
-- **💾 Negative memory usage** (-7.39 MB) - actually cleans memory during operations!
-- **⚙️ 74.55% boost** with smart caching enabled
-- **🌍 4276% faster** than Day.js in timezone conversions
-- **✅ Production tested** with 322 comprehensive tests
+- **📊 Big-data ready** - efficient for bulk/1M-operation workloads
+- **💾 Stable memory** - object pooling + LRU eviction; net heap delta is GC-dependent (often negative)
+- **⚙️ ~70% boost** with smart caching enabled
+- **🌍 Over 40x faster** (≈4300%) than Day.js in timezone conversions
+- **✅ Production tested** with 499 comprehensive tests
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -392,10 +392,10 @@ node benchmark2.js
 <!-- BENCH:readme-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **309ms** | 1717ms | 971ms | 1266ms | **~214% faster** than Day.js |
-| **Time Operations** | **595ms** | 1960ms | 789ms | 3065ms | **~33% faster** than Day.js |
-| **Timezone Conversions** | **598ms** | 3677ms | 25507ms | 5650ms | **~515% faster** than Moment |
-| **Complex Operations** | **550ms** | 3626ms | 1852ms | 3798ms | **~237% faster** than Day.js |
+| **Date Creation & Formatting** | **254ms** | 1545ms | 915ms | 1248ms | **~260% faster** than Day.js |
+| **Time Operations** | **548ms** | 1753ms | 730ms | 3162ms | **~33% faster** than Day.js |
+| **Timezone Conversions** | **474ms** | 3485ms | 23790ms | 5064ms | **~635% faster** than Moment |
+| **Complex Operations** | **489ms** | 3375ms | 1700ms | 3741ms | **~248% faster** than Day.js |
 <!-- /BENCH:readme-seq -->
 
 ### Overall Performance Summary
@@ -405,10 +405,10 @@ kk-date wins the overall sequential run, though Day.js is faster in the isolated
 <!-- BENCH:readme-overall -->
 | Library | Total Time | Operations/sec | Performance |
 |---------|------------|---------------|-------------|
-| **kk-date** | **2.05s** | **194,900 ops/sec** | 🏆 **Winner** |
-| Moment.js | 10.98s | 36,428 ops/sec | ~435% slower |
-| Luxon | 13.78s | 29,031 ops/sec | ~571% slower |
-| Day.js | 29.12s | 13,737 ops/sec | **~1319% slower** |
+| **kk-date** | **1.76s** | **226,707 ops/sec** | 🏆 **Winner** |
+| Moment.js | 10.16s | 39,378 ops/sec | ~476% slower |
+| Luxon | 13.21s | 30,269 ops/sec | ~649% slower |
+| Day.js | 27.14s | 14,741 ops/sec | **~1438% slower** |
 <!-- /BENCH:readme-overall -->
 
 ### Memory & Bundle Size
@@ -418,10 +418,10 @@ Net heap delta after creating 100,000 date instances (from `node benchmark.js`).
 <!-- BENCH:readme-memory -->
 | Library | Heap Δ / 100k instances* | Bundle Size | DST Support |
 |---------|--------------------------|-------------|-------------|
-| **kk-date** | ~+4 MB | **15 KB** | **Built-in** |
-| Moment.js | ~-3 MB* | 297 KB | Plugin required |
-| Day.js | ~-1 MB* | 18.5 KB | Plugin required |
-| Luxon | ~-4 MB* | 71 KB | Built-in |
+| **kk-date** | ~+6 MB | **15 KB** | **Built-in** |
+| Moment.js | ~+16 MB | 297 KB | Plugin required |
+| Day.js | ~-4 MB* | 18.5 KB | Plugin required |
+| Luxon | ~+5 MB | 71 KB | Built-in |
 <!-- /BENCH:readme-memory -->
 
 <sub>* GC-timing artifact — varies run-to-run and can be negative for multiple libraries; reproduce with `node benchmark.js`.</sub>
@@ -441,7 +441,7 @@ console.log((after - before) / 1024 / 1024, 'MB'); // GC-dependent; can be negat
 **Without Cache vs With Cache (representative run):**
 <!-- BENCH:readme-cache -->
 - **~69% faster** repeated operations when cache is enabled
-- Average operation time: ~113ms → ~35ms with cache
+- Average operation time: ~104ms → ~32ms with cache
 - Cache hit ratio: **100%** for repeated operations
 <!-- /BENCH:readme-cache -->
 - Memory overhead: Minimal (< 10MB for 10,000 cached items)

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ A blazing-fast JavaScript date library with intelligent caching, automatic DST d
 
 ### Performance & Efficiency *(measured on Node.js 26; reproduced by CI, results vary)*
 <!-- BENCH:readme-why -->
-- **⚡ Lightning Fast** - Over 50x faster timezone operations than Day.js
-- **🚀 ~86% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")
+- **⚡ Lightning Fast** - Over 40x faster timezone operations than Day.js
+- **🚀 ~84% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")
 - **💾 Memory Efficient** - Object pooling + LRU cache eviction keep long-running processes stable
-- **⚙️ Smart Caching** - ~69% faster repeated operations with built-in caching
+- **⚙️ Smart Caching** - ~72% faster repeated operations with built-in caching
 <!-- /BENCH:readme-why -->
 
 ### Reliability & Safety
@@ -392,10 +392,10 @@ node benchmark2.js
 <!-- BENCH:readme-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **272ms** | 1588ms | 922ms | 1239ms | **~239% faster** than Day.js |
-| **Time Operations** | **560ms** | 1743ms | 741ms | 3248ms | **~32% faster** than Day.js |
-| **Timezone Conversions** | **467ms** | 3503ms | 24013ms | 5054ms | **~650% faster** than Moment |
-| **Complex Operations** | **509ms** | 3426ms | 1720ms | 3808ms | **~238% faster** than Day.js |
+| **Date Creation & Formatting** | **190ms** | 1128ms | 726ms | 905ms | **~281% faster** than Day.js |
+| **Time Operations** | **426ms** | 1256ms | 556ms | 2733ms | **~31% faster** than Day.js |
+| **Timezone Conversions** | **416ms** | 3285ms | 18959ms | 4450ms | **~690% faster** than Moment |
+| **Complex Operations** | **337ms** | 2510ms | 1230ms | 2920ms | **~265% faster** than Day.js |
 <!-- /BENCH:readme-seq -->
 
 ### Overall Performance Summary
@@ -405,10 +405,10 @@ kk-date wins the overall sequential run, though Day.js is faster in the isolated
 <!-- BENCH:readme-overall -->
 | Library | Total Time | Operations/sec | Performance |
 |---------|------------|---------------|-------------|
-| **kk-date** | **1.81s** | **221,295 ops/sec** | 🏆 **Winner** |
-| Moment.js | 10.26s | 38,983 ops/sec | ~468% slower |
-| Luxon | 13.35s | 29,964 ops/sec | ~639% slower |
-| Day.js | 27.40s | 14,601 ops/sec | **~1416% slower** |
+| **kk-date** | **1.37s** | **292,279 ops/sec** | 🏆 **Winner** |
+| Moment.js | 8.18s | 48,907 ops/sec | ~498% slower |
+| Luxon | 11.01s | 36,340 ops/sec | ~704% slower |
+| Day.js | 21.47s | 18,630 ops/sec | **~1469% slower** |
 <!-- /BENCH:readme-overall -->
 
 ### Memory & Bundle Size
@@ -419,9 +419,9 @@ Net heap delta after creating 100,000 date instances (from `node benchmark.js`).
 | Library | Heap Δ / 100k instances* | Bundle Size | DST Support |
 |---------|--------------------------|-------------|-------------|
 | **kk-date** | ~+6 MB | **15 KB** | **Built-in** |
-| Moment.js | ~-16 MB* | 297 KB | Plugin required |
-| Day.js | ~+28 MB | 18.5 KB | Plugin required |
-| Luxon | ~-27 MB* | 71 KB | Built-in |
+| Moment.js | ~+16 MB | 297 KB | Plugin required |
+| Day.js | ~-4 MB* | 18.5 KB | Plugin required |
+| Luxon | ~+5 MB | 71 KB | Built-in |
 <!-- /BENCH:readme-memory -->
 
 <sub>* GC-timing artifact — varies run-to-run and can be negative for multiple libraries; reproduce with `node benchmark.js`.</sub>
@@ -440,8 +440,8 @@ console.log((after - before) / 1024 / 1024, 'MB'); // GC-dependent; can be negat
 
 **Without Cache vs With Cache (representative run):**
 <!-- BENCH:readme-cache -->
-- **~69% faster** repeated operations when cache is enabled
-- Average operation time: ~108ms → ~33ms with cache
+- **~72% faster** repeated operations when cache is enabled
+- Average operation time: ~106ms → ~30ms with cache
 - Cache hit ratio: **100%** for repeated operations
 <!-- /BENCH:readme-cache -->
 - Memory overhead: minimal (caches are LRU-capped at 10,000 entries)
@@ -461,12 +461,12 @@ kk_date.caching({ status: true, defaultTtl: 3600 });
 ### Key Performance Advantages
 
 <!-- BENCH:readme-advantages -->
-- **⚡ ~86% faster** than the average of competing libraries (comprehensive benchmark)
+- **⚡ ~84% faster** than the average of competing libraries (comprehensive benchmark)
 - **🚀 up to ~98% faster** in timezone operations (critical for global apps)
 - **📊 Big-data ready** - efficient for bulk/1M-operation workloads
 - **💾 Stable memory** - object pooling + LRU eviction; net heap delta is GC-dependent (often negative)
-- **⚙️ ~69% boost** with smart caching enabled
-- **🌍 Over 50x faster** (≈5000%) than Day.js in timezone conversions
+- **⚙️ ~72% boost** with smart caching enabled
+- **🌍 Over 40x faster** (≈4500%) than Day.js in timezone conversions
 <!-- /BENCH:readme-advantages -->
 - **✅ Production tested** with 499 comprehensive tests
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A blazing-fast JavaScript date library with intelligent caching, automatic DST d
 
 ## 🌟 Why Choose kk-date?
 
-### Performance & Efficiency *(measured on Node.js 22; reproduced by CI, results vary)*
+### Performance & Efficiency *(measured on Node.js 26; reproduced by CI, results vary)*
 - **⚡ Lightning Fast** - Over 40x faster timezone operations than Day.js
 - **🚀 ~80% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")
 - **💾 Memory Efficient** - Object pooling + LRU cache eviction keep long-running processes stable
@@ -376,7 +376,7 @@ console.log(date.format('DD/MM/YYYY')); // 23/08/2024
 
 ## 📊 Performance Benchmarks
 
-> **Note:** All performance figures in this README come from our own benchmark suite on Node.js 22 and are **reproduced by CI on every PR** (the "Performance Benchmarks" job runs `benchmark.js` + `benchmark2.js` and uploads the results). They are **not guarantees** — results vary by workload, hardware, Node version, and caching. Reproduce locally with `node benchmark.js` / `node benchmark2.js`. kk-date wins most scenarios but not all (e.g. Day.js is faster in isolated "Time Operations").
+> **Note:** All performance figures in this README come from our own benchmark suite on Node.js 26 and are **reproduced by CI on every PR** (the "Performance Benchmarks" job runs `benchmark.js` + `benchmark2.js` and uploads the results). They are **not guarantees** — results vary by workload, hardware, Node version, and caching. Reproduce locally with `node benchmark.js` / `node benchmark2.js`. kk-date wins most scenarios but not all (e.g. Day.js is faster in isolated "Time Operations").
 
 ### Real-World Sequential Operations (1000 days, 100 operations/day)
 
@@ -387,7 +387,7 @@ Our benchmark simulates real-world usage by processing 1000 sequential days with
 node benchmark2.js
 ```
 
-**Representative run (Node.js 22) — reproduced by CI on every PR (see the "Performance Benchmarks" job artifacts). Numbers vary run-to-run.** Totals are for 100,000 operations per scenario:
+**Representative run (Node.js 26) — reproduced by CI on every PR (see the "Performance Benchmarks" job artifacts). Numbers vary run-to-run.** Totals are for 100,000 operations per scenario:
 
 <!-- BENCH:readme-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |

--- a/README.md
+++ b/README.md
@@ -392,10 +392,10 @@ node benchmark2.js
 <!-- BENCH:readme-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **284ms** | 667ms | 487ms | 627ms | **~72% faster** than Day.js |
-| **Time Operations** | 439ms | 754ms | **357ms** | 1580ms | **~23% slower** than Day.js |
-| **Timezone Conversions** | **304ms** | 1085ms | 12586ms | 2314ms | **~257% faster** than Moment |
-| **Complex Operations** | **524ms** | 1318ms | 825ms | 1768ms | **~57% faster** than Day.js |
+| **Date Creation & Formatting** | **309ms** | 1717ms | 971ms | 1266ms | **~214% faster** than Day.js |
+| **Time Operations** | **595ms** | 1960ms | 789ms | 3065ms | **~33% faster** than Day.js |
+| **Timezone Conversions** | **598ms** | 3677ms | 25507ms | 5650ms | **~515% faster** than Moment |
+| **Complex Operations** | **550ms** | 3626ms | 1852ms | 3798ms | **~237% faster** than Day.js |
 <!-- /BENCH:readme-seq -->
 
 ### Overall Performance Summary
@@ -405,10 +405,10 @@ kk-date wins the overall sequential run, though Day.js is faster in the isolated
 <!-- BENCH:readme-overall -->
 | Library | Total Time | Operations/sec | Performance |
 |---------|------------|---------------|-------------|
-| **kk-date** | **1.55s** | **257,958 ops/sec** | 🏆 **Winner** |
-| Moment.js | 3.82s | 104,629 ops/sec | ~147% slower |
-| Luxon | 6.29s | 63,598 ops/sec | ~306% slower |
-| Day.js | 14.25s | 28,062 ops/sec | **~819% slower** |
+| **kk-date** | **2.05s** | **194,900 ops/sec** | 🏆 **Winner** |
+| Moment.js | 10.98s | 36,428 ops/sec | ~435% slower |
+| Luxon | 13.78s | 29,031 ops/sec | ~571% slower |
+| Day.js | 29.12s | 13,737 ops/sec | **~1319% slower** |
 <!-- /BENCH:readme-overall -->
 
 ### Memory & Bundle Size
@@ -420,8 +420,8 @@ Net heap delta after creating 100,000 date instances (from `node benchmark.js`).
 |---------|--------------------------|-------------|-------------|
 | **kk-date** | ~+4 MB | **15 KB** | **Built-in** |
 | Moment.js | ~-3 MB* | 297 KB | Plugin required |
-| Day.js | ~0 MB | 18.5 KB | Plugin required |
-| Luxon | ~+4 MB | 71 KB | Built-in |
+| Day.js | ~-1 MB* | 18.5 KB | Plugin required |
+| Luxon | ~-4 MB* | 71 KB | Built-in |
 <!-- /BENCH:readme-memory -->
 
 <sub>* GC-timing artifact — varies run-to-run and can be negative for multiple libraries; reproduce with `node benchmark.js`.</sub>
@@ -441,7 +441,7 @@ console.log((after - before) / 1024 / 1024, 'MB'); // GC-dependent; can be negat
 **Without Cache vs With Cache (representative run):**
 <!-- BENCH:readme-cache -->
 - **~69% faster** repeated operations when cache is enabled
-- Average operation time: ~67ms → ~21ms with cache
+- Average operation time: ~113ms → ~35ms with cache
 - Cache hit ratio: **100%** for repeated operations
 <!-- /BENCH:readme-cache -->
 - Memory overhead: Minimal (< 10MB for 10,000 cached items)

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A blazing-fast JavaScript date library with intelligent caching, automatic DST d
 
 ### Performance & Efficiency *(measured on Node.js 26; reproduced by CI, results vary)*
 <!-- BENCH:readme-why -->
-- **⚡ Lightning Fast** - Over 40x faster timezone operations than Day.js
-- **🚀 ~82% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")
+- **⚡ Lightning Fast** - Over 50x faster timezone operations than Day.js
+- **🚀 ~86% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")
 - **💾 Memory Efficient** - Object pooling + LRU cache eviction keep long-running processes stable
 - **⚙️ Smart Caching** - ~69% faster repeated operations with built-in caching
 <!-- /BENCH:readme-why -->
@@ -392,10 +392,10 @@ node benchmark2.js
 <!-- BENCH:readme-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **284ms** | 667ms | 487ms | 627ms | **~72% faster** than Day.js |
-| **Time Operations** | 439ms | 754ms | **357ms** | 1580ms | **~23% slower** than Day.js |
-| **Timezone Conversions** | **304ms** | 1085ms | 12586ms | 2314ms | **~257% faster** than Moment |
-| **Complex Operations** | **524ms** | 1318ms | 825ms | 1768ms | **~57% faster** than Day.js |
+| **Date Creation & Formatting** | **272ms** | 1588ms | 922ms | 1239ms | **~239% faster** than Day.js |
+| **Time Operations** | **560ms** | 1743ms | 741ms | 3248ms | **~32% faster** than Day.js |
+| **Timezone Conversions** | **467ms** | 3503ms | 24013ms | 5054ms | **~650% faster** than Moment |
+| **Complex Operations** | **509ms** | 3426ms | 1720ms | 3808ms | **~238% faster** than Day.js |
 <!-- /BENCH:readme-seq -->
 
 ### Overall Performance Summary
@@ -405,10 +405,10 @@ kk-date wins the overall sequential run, though Day.js is faster in the isolated
 <!-- BENCH:readme-overall -->
 | Library | Total Time | Operations/sec | Performance |
 |---------|------------|---------------|-------------|
-| **kk-date** | **1.55s** | **257,958 ops/sec** | 🏆 **Winner** |
-| Moment.js | 3.82s | 104,629 ops/sec | ~147% slower |
-| Luxon | 6.29s | 63,598 ops/sec | ~306% slower |
-| Day.js | 14.25s | 28,062 ops/sec | **~819% slower** |
+| **kk-date** | **1.81s** | **221,295 ops/sec** | 🏆 **Winner** |
+| Moment.js | 10.26s | 38,983 ops/sec | ~468% slower |
+| Luxon | 13.35s | 29,964 ops/sec | ~639% slower |
+| Day.js | 27.40s | 14,601 ops/sec | **~1416% slower** |
 <!-- /BENCH:readme-overall -->
 
 ### Memory & Bundle Size
@@ -418,10 +418,10 @@ Net heap delta after creating 100,000 date instances (from `node benchmark.js`).
 <!-- BENCH:readme-memory -->
 | Library | Heap Δ / 100k instances* | Bundle Size | DST Support |
 |---------|--------------------------|-------------|-------------|
-| **kk-date** | ~+4 MB | **15 KB** | **Built-in** |
-| Moment.js | ~-3 MB* | 297 KB | Plugin required |
-| Day.js | ~0 MB | 18.5 KB | Plugin required |
-| Luxon | ~+4 MB | 71 KB | Built-in |
+| **kk-date** | ~+6 MB | **15 KB** | **Built-in** |
+| Moment.js | ~-16 MB* | 297 KB | Plugin required |
+| Day.js | ~+28 MB | 18.5 KB | Plugin required |
+| Luxon | ~-27 MB* | 71 KB | Built-in |
 <!-- /BENCH:readme-memory -->
 
 <sub>* GC-timing artifact — varies run-to-run and can be negative for multiple libraries; reproduce with `node benchmark.js`.</sub>
@@ -441,7 +441,7 @@ console.log((after - before) / 1024 / 1024, 'MB'); // GC-dependent; can be negat
 **Without Cache vs With Cache (representative run):**
 <!-- BENCH:readme-cache -->
 - **~69% faster** repeated operations when cache is enabled
-- Average operation time: ~67ms → ~21ms with cache
+- Average operation time: ~108ms → ~33ms with cache
 - Cache hit ratio: **100%** for repeated operations
 <!-- /BENCH:readme-cache -->
 - Memory overhead: minimal (caches are LRU-capped at 10,000 entries)
@@ -461,12 +461,12 @@ kk_date.caching({ status: true, defaultTtl: 3600 });
 ### Key Performance Advantages
 
 <!-- BENCH:readme-advantages -->
-- **⚡ ~82% faster** than the average of competing libraries (comprehensive benchmark)
+- **⚡ ~86% faster** than the average of competing libraries (comprehensive benchmark)
 - **🚀 up to ~98% faster** in timezone operations (critical for global apps)
 - **📊 Big-data ready** - efficient for bulk/1M-operation workloads
 - **💾 Stable memory** - object pooling + LRU eviction; net heap delta is GC-dependent (often negative)
 - **⚙️ ~69% boost** with smart caching enabled
-- **🌍 Over 40x faster** (≈4000%) than Day.js in timezone conversions
+- **🌍 Over 50x faster** (≈5000%) than Day.js in timezone conversions
 <!-- /BENCH:readme-advantages -->
 - **✅ Production tested** with 499 comprehensive tests
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ A blazing-fast JavaScript date library with intelligent caching, automatic DST d
 ## 🌟 Why Choose kk-date?
 
 ### Performance & Efficiency *(measured on Node.js 26; reproduced by CI, results vary)*
+<!-- BENCH:readme-why -->
 - **⚡ Lightning Fast** - Over 40x faster timezone operations than Day.js
-- **🚀 ~80% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")
+- **🚀 ~82% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")
 - **💾 Memory Efficient** - Object pooling + LRU cache eviction keep long-running processes stable
-- **⚙️ Smart Caching** - ~70% faster repeated operations with built-in caching
+- **⚙️ Smart Caching** - ~69% faster repeated operations with built-in caching
+<!-- /BENCH:readme-why -->
 
 ### Reliability & Safety
 - **🛡️ Fail-Fast Design** - Invalid dates immediately throw errors, preventing silent bugs in production
@@ -21,9 +23,9 @@ A blazing-fast JavaScript date library with intelligent caching, automatic DST d
 - **🔒 Production Tested** - 499 comprehensive tests covering edge cases and DST transitions
 
 ### Features & Compatibility
-- **🌍 Accurate Timezone Handling** - 95-99% faster timezone conversions with perfect accuracy
+- **🌍 Accurate Timezone Handling** - Fast, DST-aware timezone conversions with perfect accuracy
 - **🧠 Zero-Config DST** - Automatic Daylight Saving Time detection without manual intervention
-- **📊 Big Data Ready** - Handles 1M operations with 95% better performance than competitors
+- **📊 Big Data Ready** - Handles 1M-operation workloads efficiently
 - **🌍 Production Proven** - Cross-platform compatibility with zero dependencies
 
 ## 📦 Installation
@@ -215,11 +217,9 @@ try {
 // Enable high-performance caching for massive speed improvements
 kk_date.caching({ status: true, defaultTtl: 3600 });
 
-// Real-world performance gains with caching:
-// ✅ Timezone conversions: 95-99% faster (critical for global apps)
-// ✅ Date formatting: 75% faster (essential for UI rendering)
-// ✅ Complex operations: 80% faster (important for data processing)
-// ✅ Memory efficient: < 10MB for 10,000 cached operations
+// Caching speeds up REPEATED operations (the same input parsed/formatted/converted again).
+// Measured aggregate: ~70% faster on repeated operations, ~100% cache hit ratio for repeated inputs.
+// (Distinct-input / first-time operations are already fast without caching.)
 
 // Monitor cache performance
 const stats = kk_date.caching_status();
@@ -231,14 +231,14 @@ console.log('Performance gain:', '~70%'); // Representative measured improvement
 // Handle millions of operations efficiently
 for (let i = 0; i < 1000000; i++) {
     const date = new kk_date('2024-08-23 10:00:00');
-    date.tz('America/New_York'); // First: 77ms, Cached: 20ms (74% faster!)
+    date.tz('America/New_York'); // Much faster on repeat (served from cache)
 }
 ```
 
 **When to Enable Caching:**
 - 📊 Data processing pipelines with repeated date operations
 - 🌍 Global applications with multiple timezone conversions
-- ⚡ Real-time systems requiring sub-20ms response times
+- ⚡ Real-time systems requiring low-latency date operations
 - 📈 Analytics dashboards with thousands of date calculations
 - 🔄 APIs serving high-frequency date/time requests
 
@@ -392,10 +392,10 @@ node benchmark2.js
 <!-- BENCH:readme-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **254ms** | 1545ms | 915ms | 1248ms | **~260% faster** than Day.js |
-| **Time Operations** | **548ms** | 1753ms | 730ms | 3162ms | **~33% faster** than Day.js |
-| **Timezone Conversions** | **474ms** | 3485ms | 23790ms | 5064ms | **~635% faster** than Moment |
-| **Complex Operations** | **489ms** | 3375ms | 1700ms | 3741ms | **~248% faster** than Day.js |
+| **Date Creation & Formatting** | **284ms** | 667ms | 487ms | 627ms | **~72% faster** than Day.js |
+| **Time Operations** | 439ms | 754ms | **357ms** | 1580ms | **~23% slower** than Day.js |
+| **Timezone Conversions** | **304ms** | 1085ms | 12586ms | 2314ms | **~257% faster** than Moment |
+| **Complex Operations** | **524ms** | 1318ms | 825ms | 1768ms | **~57% faster** than Day.js |
 <!-- /BENCH:readme-seq -->
 
 ### Overall Performance Summary
@@ -405,10 +405,10 @@ kk-date wins the overall sequential run, though Day.js is faster in the isolated
 <!-- BENCH:readme-overall -->
 | Library | Total Time | Operations/sec | Performance |
 |---------|------------|---------------|-------------|
-| **kk-date** | **1.76s** | **226,707 ops/sec** | 🏆 **Winner** |
-| Moment.js | 10.16s | 39,378 ops/sec | ~476% slower |
-| Luxon | 13.21s | 30,269 ops/sec | ~649% slower |
-| Day.js | 27.14s | 14,741 ops/sec | **~1438% slower** |
+| **kk-date** | **1.55s** | **257,958 ops/sec** | 🏆 **Winner** |
+| Moment.js | 3.82s | 104,629 ops/sec | ~147% slower |
+| Luxon | 6.29s | 63,598 ops/sec | ~306% slower |
+| Day.js | 14.25s | 28,062 ops/sec | **~819% slower** |
 <!-- /BENCH:readme-overall -->
 
 ### Memory & Bundle Size
@@ -418,10 +418,10 @@ Net heap delta after creating 100,000 date instances (from `node benchmark.js`).
 <!-- BENCH:readme-memory -->
 | Library | Heap Δ / 100k instances* | Bundle Size | DST Support |
 |---------|--------------------------|-------------|-------------|
-| **kk-date** | ~+6 MB | **15 KB** | **Built-in** |
-| Moment.js | ~+16 MB | 297 KB | Plugin required |
-| Day.js | ~-4 MB* | 18.5 KB | Plugin required |
-| Luxon | ~+5 MB | 71 KB | Built-in |
+| **kk-date** | ~+4 MB | **15 KB** | **Built-in** |
+| Moment.js | ~-3 MB* | 297 KB | Plugin required |
+| Day.js | ~0 MB | 18.5 KB | Plugin required |
+| Luxon | ~+4 MB | 71 KB | Built-in |
 <!-- /BENCH:readme-memory -->
 
 <sub>* GC-timing artifact — varies run-to-run and can be negative for multiple libraries; reproduce with `node benchmark.js`.</sub>
@@ -441,10 +441,10 @@ console.log((after - before) / 1024 / 1024, 'MB'); // GC-dependent; can be negat
 **Without Cache vs With Cache (representative run):**
 <!-- BENCH:readme-cache -->
 - **~69% faster** repeated operations when cache is enabled
-- Average operation time: ~104ms → ~32ms with cache
+- Average operation time: ~67ms → ~21ms with cache
 - Cache hit ratio: **100%** for repeated operations
 <!-- /BENCH:readme-cache -->
-- Memory overhead: Minimal (< 10MB for 10,000 cached items)
+- Memory overhead: minimal (caches are LRU-capped at 10,000 entries)
 
 **Why Enable Caching:**
 ```javascript
@@ -452,20 +452,22 @@ console.log((after - before) / 1024 / 1024, 'MB'); // GC-dependent; can be negat
 kk_date.caching({ status: true, defaultTtl: 3600 });
 
 // Perfect for:
-// ✅ Repeated timezone conversions (95-99% faster)
-// ✅ Frequent date formatting (75% faster)
+// ✅ Repeated timezone conversions (the biggest cache win)
+// ✅ Frequently re-formatting the same inputs
 // ✅ Large-scale data processing (handles 1M ops efficiently)
-// ✅ Real-time applications (sub-20ms response times)
+// ✅ Hot paths that re-convert/re-format the same instants
 ```
 
 ### Key Performance Advantages
 
-- **⚡ ~80% faster** than the average of competing libraries (comprehensive benchmark)
-- **🚀 95-99% faster** in timezone operations (critical for global apps)
+<!-- BENCH:readme-advantages -->
+- **⚡ ~82% faster** than the average of competing libraries (comprehensive benchmark)
+- **🚀 up to ~98% faster** in timezone operations (critical for global apps)
 - **📊 Big-data ready** - efficient for bulk/1M-operation workloads
 - **💾 Stable memory** - object pooling + LRU eviction; net heap delta is GC-dependent (often negative)
-- **⚙️ ~70% boost** with smart caching enabled
-- **🌍 Over 40x faster** (≈4300%) than Day.js in timezone conversions
+- **⚙️ ~69% boost** with smart caching enabled
+- **🌍 Over 40x faster** (≈4000%) than Day.js in timezone conversions
+<!-- /BENCH:readme-advantages -->
 - **✅ Production tested** with 499 comprehensive tests
 
 ## 🤝 Contributing

--- a/benchmark.js
+++ b/benchmark.js
@@ -38,6 +38,12 @@ const timezone = require('dayjs/plugin/timezone');
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+// `--json` mode: emit only machine-readable JSON (suppress human-readable output).
+// Used by scripts/update-benchmark-docs.js / the "Update Benchmark Docs" workflow.
+const JSON_MODE = process.argv.includes('--json');
+const _rawLog = console.log;
+if (JSON_MODE) console.log = () => {};
+
 // Enable caching for better performance
 KkDate.caching({ status: false, defaultTtl: 3600 });
 
@@ -657,9 +663,11 @@ const memoryTest = () => {
 	console.log(`  Moment:   ${momentMemory.toFixed(2)} MB`);
 	console.log(`  Day.js:   ${dayjsMemory.toFixed(2)} MB`);
 	console.log(`  Luxon:    ${luxonMemory.toFixed(2)} MB`);
+
+	return { 'kk-date': kkDateMemory, Moment: momentMemory, 'Day.js': dayjsMemory, Luxon: luxonMemory };
 };
 
-memoryTest();
+const memResult = memoryTest();
 
 // Cache performance test for all scenarios
 console.log('\n⚡ CACHE PERFORMANCE TEST');
@@ -705,9 +713,11 @@ const cacheTestAllScenarios = () => {
 	console.log(`Average without cache: ${avgNoCacheTime.toFixed(3)}ms`);
 	console.log(`Average with cache:    ${avgWithCacheTime.toFixed(3)}ms`);
 	console.log(`Cache impact:          ${cacheImprovement}% performance improvement`);
+
+	return { withoutMs: avgNoCacheTime, withMs: avgWithCacheTime, improvementPct: parseFloat(cacheImprovement) };
 };
 
-cacheTestAllScenarios();
+const cacheResult = cacheTestAllScenarios();
 
 // Cache statistics
 const cacheStats = KkDate.caching_status();
@@ -725,3 +735,24 @@ console.log(`Heap Total: ${(memUsage.heapTotal / 1024 / 1024).toFixed(2)} MB`);
 
 console.log('\n✨ Benchmark completed!');
 KkDate.caching({ status: false });
+
+if (JSON_MODE) {
+	_rawLog(
+		JSON.stringify(
+			{
+				type: 'comprehensive',
+				overall: {
+					avgMs: { 'kk-date': avgKkDateTime, Moment: avgMomentTime, 'Day.js': avgDayjsTime, Luxon: avgLuxonTime },
+					kkDateFasterPct: { Moment: parseFloat(vsMomentOverall), 'Day.js': parseFloat(vsDayjsOverall), Luxon: parseFloat(vsLuxonOverall) },
+				},
+				memory: memResult,
+				cache: {
+					...cacheResult,
+					hitRatioPct: (cacheStats.totalHits / (cacheStats.totalHits + cacheStats.cacheSize)) * 100,
+				},
+			},
+			null,
+			2,
+		),
+	);
+}

--- a/benchmark2.js
+++ b/benchmark2.js
@@ -16,6 +16,12 @@ const timezone = require('dayjs/plugin/timezone');
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+// `--json` mode: emit only machine-readable JSON (suppress human-readable output).
+// Used by scripts/update-benchmark-docs.js / the "Update Benchmark Docs" workflow.
+const JSON_MODE = process.argv.includes('--json');
+const _rawLog = console.log;
+if (JSON_MODE) console.log = () => {};
+
 // Test configuration
 const DAYS_TO_TEST = 1000;
 const ITERATIONS_PER_DAY = 100;
@@ -211,7 +217,7 @@ for (let index = 0; index < dates.length; index++) {
 	// Show progress
 	if (index % progressInterval === 0) {
 		progress = Math.floor((index / DAYS_TO_TEST) * 100);
-		process.stdout.write(`\rProgress: ${'█'.repeat(Math.floor(progress / 5))}${'░'.repeat(20 - Math.floor(progress / 5))} ${progress}%`);
+		if (!JSON_MODE) process.stdout.write(`\rProgress: ${'█'.repeat(Math.floor(progress / 5))}${'░'.repeat(20 - Math.floor(progress / 5))} ${progress}%`);
 	}
 
 	for (const scenario of scenarios) {
@@ -299,3 +305,22 @@ console.log(`RSS: ${(memUsage.rss / 1024 / 1024).toFixed(2)} MB`);
 console.log(`Heap Used: ${(memUsage.heapUsed / 1024 / 1024).toFixed(2)} MB`);
 
 console.log('\n✨ Benchmark completed!');
+
+if (JSON_MODE) {
+	const cleanName = (n) => n.replace(/^[^A-Za-z]+/, '').trim();
+	const scenariosJson = {};
+	for (const scenario of scenarios) {
+		scenariosJson[cleanName(scenario.name)] = {
+			'kk-date': results.kkdate[scenario.name],
+			Moment: results.moment[scenario.name],
+			'Day.js': results.dayjs[scenario.name],
+			Luxon: results.luxon[scenario.name],
+		};
+	}
+	const totalOps = DAYS_TO_TEST * ITERATIONS_PER_DAY * scenarios.length;
+	const overallJson = {};
+	for (const [lib, time] of Object.entries(totalTimes)) {
+		overallJson[lib] = { ms: time, ops: Math.round(totalOps / (time / 1000)) };
+	}
+	_rawLog(JSON.stringify({ type: 'sequential', scenarios: scenariosJson, overall: overallJson }, null, 2));
+}

--- a/docs/ADVANCED-USAGE.md
+++ b/docs/ADVANCED-USAGE.md
@@ -16,12 +16,12 @@ Advanced features, performance tips, and best practices for kk-date.
 
 ### Caching Strategies
 
-kk-date provides a powerful caching system that delivers **74.55% performance improvement** when enabled:
+kk-date provides a caching system that, in our benchmarks on Node.js 22, delivered up to **~70% faster** repeated operations (results vary by workload):
 
 ```javascript
 const kk_date = require('kk-date');
 
-// Enable caching for maximum performance (74.55% faster!)
+// Enable caching for maximum performance (~70% faster in our benchmarks)
 kk_date.caching({ status: true, defaultTtl: 3600 });
 
 // Monitor cache performance
@@ -75,7 +75,9 @@ const dates = [
     '2024-08-23 12:00:00'
 ];
 
-// Batch timezone conversion
+// Batch timezone conversion.
+// (Naive inputs are parsed in the process timezone; the outputs below assume UTC, i.e. TZ=UTC
+// or kk_date.setTimezone('UTC'). Use '...Z' instants for results independent of the machine.)
 const convertedDates = dates.map(dateStr => {
     const date = new kk_date(dateStr);
     return date.tz('America/New_York').format('HH:mm');
@@ -107,9 +109,11 @@ console.log(date.format(FORMATS.DATETIME)); // '2024-08-23 10:30:45'
 
 ## Memory Management
 
-### Revolutionary Negative Memory Usage
+### Memory Usage
 
-kk-date achieves **negative memory usage** (-7.39 MB), actually cleaning up more memory than it uses:
+> The net memory delta is a **GC-timing artifact**, not a guarantee — from run to run it can be **positive or negative**, and **several other libraries (e.g. Luxon) also show negative values**. It depends on workload, Node version, and GC behavior; reproduce it with `node benchmark.js` before relying on it.
+
+In our benchmarks kk-date can report **negative net memory usage** because it frees more than it allocates during the measured run:
 
 ```javascript
 // Measurement shows negative memory usage!
@@ -123,7 +127,7 @@ for (let i = 0; i < 100000; i++) {
 
 const after = process.memoryUsage().heapUsed;
 const memoryUsed = (after - before) / 1024 / 1024;
-console.log('Memory used:', memoryUsed); // -7.39 MB!
+console.log('Memory used:', memoryUsed); // GC-dependent; can be positive or negative from run to run
 ```
 
 **How it works:**
@@ -282,14 +286,15 @@ function extendKkDate() {
     // Add custom method to prototype
     kk_date.prototype.toRelativeTime = function() {
         const now = new kk_date();
+        // diff is measured as (now - this): positive when `this` is in the past.
         const diff = this.diff(now, 'minutes');
         
         if (Math.abs(diff) < 1) {
             return 'just now';
-        } else if (diff < 0) {
-            return `${Math.abs(diff)} minutes ago`;
+        } else if (diff > 0) {
+            return `${diff} minutes ago`;
         } else {
-            return `in ${diff} minutes`;
+            return `in ${Math.abs(diff)} minutes`;
         }
     };
     
@@ -340,25 +345,26 @@ const customFormatters = {
     // Relative time formatting
     relative: (date) => {
         const now = new kk_date();
+        // diff is measured as (now - date): negative when `date` is in the future.
         const diff = date.diff(now, 'days');
         
         if (diff === 0) {
             return 'Today';
-        } else if (diff === 1) {
-            return 'Tomorrow';
         } else if (diff === -1) {
+            return 'Tomorrow';
+        } else if (diff === 1) {
             return 'Yesterday';
-        } else if (diff > 0) {
-            return `In ${diff} days`;
+        } else if (diff < 0) {
+            return `In ${Math.abs(diff)} days`;
         } else {
-            return `${Math.abs(diff)} days ago`;
+            return `${diff} days ago`;
         }
     },
     
-    // Age calculation
+    // Age calculation: date.diff(now) === (now - date), positive for a past birthdate
     age: (date) => {
         const now = new kk_date();
-        const years = now.diff(date, 'years');
+        const years = date.diff(now, 'years');
         return `${years} years old`;
     },
     
@@ -514,7 +520,8 @@ const event = new Event({
 
 await event.save();
 
-// Get user time
+// Get user time (illustrative — requires the event times to already be stored as UTC instants;
+// the numbers below assume startTime was saved as 18:00 UTC, i.e. 2 PM New York):
 const userTime = event.getUserTime('Europe/London');
 console.log(userTime); // { startTime: '2024-08-23 19:00', endTime: '2024-08-23 20:00' }
 ```
@@ -535,8 +542,9 @@ kk_date.config({ locale: 'en' });
     });
     
     test('timezone conversion with DST', () => {
-        // Test DST transition
-        const dstDate = new kk_date('2024-03-10 02:00:00');
+        // 07:00 UTC on 2024-03-10 is just after New York springs forward to EDT.
+        // (Use an absolute instant so the result does not depend on the process timezone.)
+        const dstDate = new kk_date('2024-03-10T07:00:00.000Z');
         const nyTime = dstDate.tz('America/New_York');
         
         expect(nyTime.format('HH:mm')).toBe('03:00'); // EDT
@@ -560,7 +568,7 @@ kk_date.config({ locale: 'en' });
     test('error handling for invalid input', () => {
         expect(() => {
             new kk_date('invalid-date');
-        }).toThrow('Invalid date format');
+        }).toThrow('Invalid Date');
     });
     
     test('performance with caching', () => {

--- a/docs/ADVANCED-USAGE.md
+++ b/docs/ADVANCED-USAGE.md
@@ -16,7 +16,7 @@ Advanced features, performance tips, and best practices for kk-date.
 
 ### Caching Strategies
 
-kk-date provides a caching system that, in our benchmarks on Node.js 22, delivered up to **~70% faster** repeated operations (results vary by workload):
+kk-date provides a caching system that, in our benchmarks on Node.js 26, delivered up to **~70% faster** repeated operations (results vary by workload):
 
 ```javascript
 const kk_date = require('kk-date');

--- a/docs/ADVANCED-USAGE.md
+++ b/docs/ADVANCED-USAGE.md
@@ -31,18 +31,16 @@ console.log('Cache hit rate:', hitRate + '%'); // Typically 99%+
 
 // First conversion - initial computation
 const date = new kk_date('2024-08-23 10:00:00');
-const first = date.tz('America/New_York'); // ~77ms
+const first = date.tz('America/New_York'); // first call: computed
 
 // Subsequent conversions - cached results
-const second = date.tz('America/New_York'); // ~20ms (74% faster!)
-const third = date.tz('America/New_York');  // ~20ms (cached)
+const second = date.tz('America/New_York'); // much faster: served from cache
+const third = date.tz('America/New_York');  // cached
 ```
 
 **Performance Gains with Caching:**
-- **Timezone conversions**: 95-99% faster
-- **Date formatting**: 75% faster
-- **Complex operations**: 80% faster
-- **Big Data (1M operations)**: 95% faster
+
+Caching mainly helps **repeated** operations (the same input parsed/formatted/converted again) — in our benchmarks roughly a **~70% aggregate speedup** with a **~100% cache hit ratio**. Distinct-input / first-time operations are already fast without caching. See the auto-updated tables in the [README](../README.md#-performance-benchmarks) / [Performance Guide](PERFORMANCE.md) for current per-scenario numbers.
 
 ### Object Pooling
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2,6 +2,12 @@
 
 Complete reference for all kk-date methods, properties, and configuration options.
 
+> **Timezone note for examples:** A naive date string like `'2024-08-23 10:00:00'` is parsed in the
+> **process's local timezone**. The outputs shown below assume the process timezone is **UTC** (run with
+> `TZ=UTC`, or call `kk_date.setTimezone('UTC')`). Pass an absolute instant (ISO-8601 with `Z`) when you need
+> the same result on every machine. Some values (`toString()`, timezone abbreviations) also depend on the
+> runtime's ICU data and may differ across Node versions/platforms.
+
 ## Table of Contents
 
 - [Constructor](#constructor)
@@ -160,7 +166,8 @@ Returns a string representation of the date.
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:00');
-console.log(date.toString()); // 'Fri Aug 23 2024 10:30:00 GMT+0300 (GMT+03:00)'
+// Output depends on the process timezone and the runtime's ICU data, e.g. under UTC:
+console.log(date.toString()); // 'Fri Aug 23 2024 10:30:00 GMT+0000 (Coordinated Universal Time)'
 ```
 
 #### `toISOString()`
@@ -171,7 +178,7 @@ Returns ISO 8601 string representation.
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:00');
-console.log(date.toISOString()); // '2024-08-23T07:30:00.000Z' (adjusted to UTC)
+console.log(date.toISOString()); // '2024-08-23T10:30:00.000Z' (input parsed as UTC, see note above)
 ```
 
 ### Manipulation Methods
@@ -182,7 +189,7 @@ Adds the specified amount of time to the date.
 
 **Parameters:**
 - `amount` (number) - Amount to add
-- `unit` (string) - Time unit ('years', 'months', 'days', 'hours', 'minutes', 'seconds')
+- `unit` (string) - Time unit ('years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds')
 
 **Returns:** (KkDate) - Modified date instance
 
@@ -260,7 +267,9 @@ const date2 = new kk_date('2024-08-23 10:30:45');
 date2.startOf('months');               // 2024-08-01 00:00:00
 
 const date3 = new kk_date('2024-08-23 10:30:45');
-date3.startOf('weeks');                // 2024-08-19 00:00:00 (Monday)
+date3.startOf('weeks');                // 2024-08-18 00:00:00 (Sunday — the default week start)
+// For a Monday-based week, set weekStartDay first:
+//   kk_date.config({ weekStartDay: 1 });  ->  startOf('weeks') === 2024-08-19 00:00:00 (Monday)
 
 const date4 = new kk_date('2024-08-23 10:30:45');
 date4.startOf('days');                 // 2024-08-23 00:00:00
@@ -288,7 +297,7 @@ const date2 = new kk_date('2024-08-23 10:30:45');
 date2.endOf('months');                 // 2024-08-31 23:59:59.999
 
 const date3 = new kk_date('2024-08-23 10:30:45');
-date3.endOf('weeks');                  // 2024-08-25 23:59:59.999 (Sunday)
+date3.endOf('weeks');                  // 2024-08-24 23:59:59.999 (Saturday — with the default Sunday week start)
 
 const date4 = new kk_date('2024-08-23 10:30:45');
 date4.endOf('days');                   // 2024-08-23 23:59:59.999
@@ -386,15 +395,18 @@ Returns the difference between two dates.
 
 **Returns:** (number) - Difference in specified unit
 
+The difference is measured as `(date - this)`, i.e. the argument minus the receiver. So when the argument is
+**later** than the receiver the result is **positive**; when it is earlier the result is negative.
+
 **Examples:**
 ```javascript
 const date1 = new kk_date('2024-08-23');
 const date2 = new kk_date('2024-08-25');
 
-date1.diff(date2, 'days');             // -2
-date2.diff(date1, 'days');             // 2
-date1.diff(date2, 'hours');            // -48
-date1.diff(date2, 'days', true);       // -2.0
+date1.diff(date2, 'days');             // 2   (date2 is 2 days after date1)
+date2.diff(date1, 'days');             // -2  (date1 is 2 days before date2)
+date1.diff(date2, 'hours');            // 48
+date1.diff(date2, 'days', true);       // 2   (asFloat returns a fractional value when not a whole number)
 ```
 
 ### Timezone Methods
@@ -477,8 +489,10 @@ Gets the timezone abbreviation.
 const date = new kk_date('2024-08-23 10:00:00');
 
 date.getTimezoneAbbreviation('America/New_York'); // 'EDT'
-date.getTimezoneAbbreviation('Europe/London');    // 'BST'
-date.getTimezoneAbbreviation('Asia/Tokyo');       // 'JST'
+// Note: the exact abbreviation comes from the runtime's ICU data. Some Node.js/ICU builds return an
+// offset-style label instead of a short name, e.g. 'GMT+1' for Europe/London and 'GMT+9' for Asia/Tokyo.
+date.getTimezoneAbbreviation('Europe/London');    // 'BST' or 'GMT+1' (runtime-dependent)
+date.getTimezoneAbbreviation('Asia/Tokyo');       // 'JST' or 'GMT+9' (runtime-dependent)
 ```
 
 ### Utility Methods
@@ -492,10 +506,11 @@ Checks if the date is valid.
 **Examples:**
 ```javascript
 const validDate = new kk_date('2024-08-23');
-const invalidDate = new kk_date('invalid');
-
 validDate.isValid();                   // true
-invalidDate.isValid();                 // false
+
+// Note: the constructor is fail-fast — `new kk_date('invalid')` THROWS immediately, so you cannot
+// reach `.isValid() === false` through it. To test a raw string without throwing, use the static
+// `kk_date.isValid(input, format)` instead (see Static Methods below).
 ```
 
 #### `getTime()`
@@ -632,6 +647,8 @@ Gets the global default timezone.
 ```javascript
 const kk_date = require('kk-date');
 
+// Defaults to the system timezone until you call setTimezone()/config({ timezone }).
+kk_date.setTimezone('UTC');
 const currentTimezone = kk_date.getTimezone();
 console.log(currentTimezone); // 'UTC'
 ```
@@ -664,6 +681,8 @@ Gets the user's preferred timezone.
 ```javascript
 const kk_date = require('kk-date');
 
+// Defaults to the system timezone until you call setUserTimezone().
+kk_date.setUserTimezone('America/New_York');
 const userTimezone = kk_date.getUserTimezone();
 console.log(userTimezone); // 'America/New_York'
 ```
@@ -709,15 +728,15 @@ kk_date.config({
 
 ### Utility Methods
 
-#### `isValid(input, format?)`
+#### `isValid(input, format)`
 
-Checks if a date input is valid.
+Checks whether a date string matches a given format template.
 
 **Note:** This is a module-level export, not a class static method.
 
 **Parameters:**
-- `input` (any) - Input to validate
-- `format` (string, optional) - Format to validate against ('YYYY-MM-DD', 'YYYY-DD-MM', etc.)
+- `input` (string) - Date string to validate
+- `format` (string, **required**) - Format to validate against ('YYYY-MM-DD', 'YYYY-DD-MM', etc.). Omitting it throws `Error: Invalid template !`.
 
 **Returns:** (boolean) - True if valid
 
@@ -725,11 +744,12 @@ Checks if a date input is valid.
 ```javascript
 const kk_date = require('kk-date');
 
-kk_date.isValid('2024-08-23');        // true
-kk_date.isValid('invalid');            // false
-kk_date.isValid(new Date());           // true
-kk_date.isValid('2024-23-08', 'YYYY-DD-MM'); // true
-kk_date.isValid('2024-23-08', 'YYYY-MM-DD'); // false
+// A format template is REQUIRED. Calling isValid() with only one argument throws
+// `Error: Invalid template !`, and passing a non-string (e.g. a Date) returns false.
+kk_date.isValid('2024-08-23', 'YYYY-MM-DD');  // true
+kk_date.isValid('invalid', 'YYYY-MM-DD');     // false
+kk_date.isValid('2024-23-08', 'YYYY-DD-MM');  // true
+kk_date.isValid('2024-23-08', 'YYYY-MM-DD');  // false
 ```
 
 #### `getTimezoneOffset(timezone, date?)`
@@ -858,7 +878,7 @@ The library throws descriptive errors for invalid operations:
 try {
     const date = new kk_date('invalid');
 } catch (error) {
-    console.log(error.message); // 'Invalid date format'
+    console.log(error.message); // 'Invalid Date'
 }
 
 try {

--- a/docs/CONFIGURATION-GUIDE.md
+++ b/docs/CONFIGURATION-GUIDE.md
@@ -18,6 +18,11 @@ Complete guide to configuring kk-date, including global settings, instance optio
 
 kk-date provides flexible configuration options at both global and instance levels. This allows you to set default behaviors for your entire application while still having the flexibility to override settings for specific use cases.
 
+> **How to read the examples below:**
+> - Outputs assume the **global/process timezone is UTC** (set via `kk_date.setTimezone('UTC')`, or run with `TZ=UTC`).
+> - Instance `config({ timezone })` and `.tz()` change only the **display** timezone — they do **not** reinterpret the input string. A naive string is always parsed in the global/system timezone.
+> - `.tz()` **mutates** the instance and returns it, so use a **fresh instance per conversion** (do not read the original after calling `.tz()` on it).
+
 ### Configuration Levels
 
 1. **Global Configuration**: Affects all new instances
@@ -31,14 +36,14 @@ kk-date provides flexible configuration options at both global and instance leve
 ```javascript
 const kk_date = require('kk-date');
 
-// Set global default timezone
+// Set global default timezone (the most recent call wins)
 kk_date.setTimezone('UTC');
 kk_date.setTimezone('America/New_York');
 kk_date.setTimezone('Europe/London');
 
 // Get current global timezone
 const currentTimezone = kk_date.getTimezone();
-console.log(currentTimezone); // 'UTC'
+console.log(currentTimezone); // 'Europe/London' (the last value set)
 ```
 
 ### Setting User Timezone
@@ -121,11 +126,12 @@ date.config({
 #### Timezone Configuration
 
 ```javascript
-// Create instance with specific timezone
+// Create instance, then display it in a specific timezone (global timezone = UTC)
 const nyDate = new kk_date('2024-08-23 10:00:00');
 nyDate.config({ timezone: 'America/New_York' });
 
-console.log(nyDate.format('HH:mm')); // '10:00' (interpreted as NY time)
+// config({ timezone }) only changes the DISPLAY zone; the 10:00 input (parsed as UTC) shows as NY local:
+console.log(nyDate.format('HH:mm')); // '06:00'
 ```
 
 #### Locale Configuration
@@ -166,12 +172,12 @@ Configuration options follow a specific priority order:
 // Global: UTC
 kk_date.setTimezone('UTC');
 
-// Instance: New York (overrides global)
+// Instance: display in New York (overrides the global display zone)
 const nyDate = new kk_date('2024-08-23 10:00:00');
 nyDate.config({ timezone: 'America/New_York' });
 
-// Result: Uses New York timezone
-console.log(nyDate.format('HH:mm')); // '10:00' (NY time)
+// Result: 10:00 UTC displayed in New York
+console.log(nyDate.format('HH:mm')); // '06:00' (NY display)
 
 // Instance: No timezone specified (uses global)
 const utcDate = new kk_date('2024-08-23 10:00:00');
@@ -218,12 +224,10 @@ console.log(date2.format('HH:mm')); // '15:00' (UTC)
 ```javascript
 // Store user's timezone preference
 kk_date.setUserTimezone('America/New_York');
+kk_date.setTimezone('UTC'); // server works in UTC
 
-// Use user timezone for display
-const serverTime = new kk_date('2024-08-23 15:00:00');
-            date.config({timezone: 'UTC'});
-
-const userTime = serverTime.tz(kk_date.getUserTimezone());
+// Convert a fresh instance to the user's timezone for display
+const userTime = new kk_date('2024-08-23 15:00:00').tz(kk_date.getUserTimezone());
 console.log('Time for user:', userTime.format('HH:mm')); // '11:00'
 ```
 
@@ -249,10 +253,11 @@ try {
 // Server always uses UTC
 kk_date.setTimezone('UTC');
 
-// Convert to user timezone for display
+// Convert to user timezone for display.
+// Use a fresh instance for the conversion — .tz() mutates the instance it is called on.
 const serverTime = new kk_date('2024-08-23 15:00:00');
 const userTimezone = 'America/New_York';
-const userTime = serverTime.tz(userTimezone);
+const userTime = new kk_date('2024-08-23 15:00:00').tz(userTimezone);
 
 console.log('Server time:', serverTime.format('HH:mm')); // '15:00'
 console.log('User time:', userTime.format('HH:mm'));     // '11:00'
@@ -290,8 +295,9 @@ function createTenantDate(dateString, tenantId) {
 const tenant1Date = createTenantDate('2024-08-23 10:00:00', 'tenant1');
 const tenant2Date = createTenantDate('2024-08-23 10:00:00', 'tenant2');
 
-console.log(tenant1Date.format('HH:mm')); // '10:00' (NY time)
-console.log(tenant2Date.format('HH:mm')); // '10:00' (London time)
+// 10:00 UTC displayed in each tenant's timezone (config({ timezone }) is display-only):
+console.log(tenant1Date.format('HH:mm')); // '06:00' (New York)
+console.log(tenant2Date.format('HH:mm')); // '11:00' (London)
 ```
 
 ## Locale Configuration
@@ -330,12 +336,12 @@ locales.forEach(locale => {
     console.log(`${locale}: ${date.format('dddd, DD MMMM YYYY')}`);
 });
 
-// Output:
+// Output (fr/es weekday & month names are lowercased by Intl):
 // en: Friday, 23 August 2024
 // tr: Cuma, 23 Ağustos 2024
 // de: Freitag, 23 August 2024
-// fr: Vendredi, 23 août 2024
-// es: Viernes, 23 agosto 2024
+// fr: vendredi, 23 août 2024
+// es: viernes, 23 agosto 2024
 ```
 
 ### Supported Locales
@@ -371,15 +377,15 @@ kk_date.config({ weekStartDay: 0 });
 ### Week Start Day Examples
 
 ```javascript
-const date = new kk_date('2024-08-23 10:00:00'); // Friday
+// Use a fresh instance for each call — startOf() mutates the instance it is called on.
 
 // Week starts on Sunday (default)
 kk_date.config({ weekStartDay: 0 });
-console.log(date.startOf('weeks').format('YYYY-MM-DD')); // '2024-08-18' (Sunday)
+console.log(new kk_date('2024-08-23 10:00:00').startOf('weeks').format('YYYY-MM-DD')); // '2024-08-18' (Sunday)
 
 // Week starts on Monday
 kk_date.config({ weekStartDay: 1 });
-console.log(date.startOf('weeks').format('YYYY-MM-DD')); // '2024-08-19' (Monday)
+console.log(new kk_date('2024-08-23 10:00:00').startOf('weeks').format('YYYY-MM-DD')); // '2024-08-19' (Monday)
 ```
 
 ### Instance-Specific Week Start Day

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -177,7 +177,7 @@ All new functionality must include tests. Follow these guidelines:
        test('should throw error for invalid input', () => {
          expect(() => {
            new kk_date('invalid-date')
-         }).toThrow('Invalid date format')
+         }).toThrow('Invalid Date')
        })
      })
    })

--- a/docs/FORMATTING-GUIDE.md
+++ b/docs/FORMATTING-GUIDE.md
@@ -89,8 +89,8 @@ date.format('DD'); // '23'
 const date = new kk_date('2024-08-23 22:30:45');
 
 date.format('HH'); // '22'
-// For 12-hour format, use combined formats:
-date.format('hh:mm'); // '10:30' (12-hour format with AM/PM)
+// For 12-hour format, use combined formats (an AM/PM suffix is always appended):
+date.format('hh:mm'); // '10:30 PM'
 ```
 
 ### Minute Templates
@@ -232,16 +232,16 @@ date.format('YYYY MMMM DD'); // '2024 August 23'
 |----------|-------------|---------|
 | `HH:mm:ss` | 24-hour time with seconds | `10:30:45` |
 | `HH:mm` | 24-hour time without seconds | `10:30` |
-| `hh:mm:ss` | 12-hour time with seconds | `10:30:45` |
-| `hh:mm` | 12-hour time without seconds | `10:30` |
+| `hh:mm:ss` | 12-hour time with seconds (AM/PM suffix) | `10:30:45 AM` |
+| `hh:mm` | 12-hour time without seconds (AM/PM suffix) | `10:30 AM` |
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:45');
 
 date.format('HH:mm:ss'); // '10:30:45'
 date.format('HH:mm');    // '10:30'
-date.format('hh:mm:ss'); // '10:30:45'
-date.format('hh:mm');    // '10:30'
+date.format('hh:mm:ss'); // '10:30:45 AM'
+date.format('hh:mm');    // '10:30 AM'
 ```
 
 ### Time with Milliseconds
@@ -249,13 +249,13 @@ date.format('hh:mm');    // '10:30'
 | Template | Description | Example |
 |----------|-------------|---------|
 | `HH:mm:ss.SSS` | 24-hour time with milliseconds | `10:30:45.123` |
-| `hh:mm:ss.SSS` | 12-hour time with milliseconds | `10:30:45.123` |
+| `hh:mm:ss.SSS` | 12-hour time with milliseconds (AM/PM suffix) | `10:30:45.123 AM` |
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:45.123');
 
 date.format('HH:mm:ss.SSS'); // '10:30:45.123'
-date.format('hh:mm:ss.SSS'); // '10:30:45.123'
+date.format('hh:mm:ss.SSS'); // '10:30:45.123 AM'
 ```
 
 ### Individual Time Components
@@ -289,7 +289,6 @@ date.format('HH:mm:ss.SSS'); // '10:30:45.123'
 | `DD.MM.YYYY HH:mm:ss` | European datetime format | `23.08.2024 10:30:45` |
 | `DD.MM.YYYY HH:mm` | European datetime without seconds | `23.08.2024 10:30` |
 | `DD-MM-YYYY HH:mm:ss` | European datetime with dashes | `23-08-2024 10:30:45` |
-| `MM/DD/YYYY HH:mm:ss` | US datetime format | `08/23/2024 10:30:45` |
 | `YYYY.MM.DD HH:mm:ss` | Dotted datetime format | `2024.08.23 10:30:45` |
 | `YYYY.MM.DD HH:mm` | Dotted datetime without seconds | `2024.08.23 10:30` |
 
@@ -301,7 +300,6 @@ date.format('YYYY-MM-DD HH:mm');    // '2024-08-23 10:30'
 date.format('DD.MM.YYYY HH:mm:ss'); // '23.08.2024 10:30:45'
 date.format('DD.MM.YYYY HH:mm');    // '23.08.2024 10:30'
 date.format('DD-MM-YYYY HH:mm:ss'); // '23-08-2024 10:30:45'
-date.format('MM/DD/YYYY HH:mm:ss'); // '08/23/2024 10:30:45'
 date.format('YYYY.MM.DD HH:mm:ss'); // '2024.08.23 10:30:45'
 date.format('YYYY.MM.DD HH:mm');    // '2024.08.23 10:30'
 ```
@@ -322,7 +320,6 @@ date.format('YYYY-MM-DDTHH:mm:ss'); // '2024-08-23T10:30:45'
 
 | Template | Description | Example |
 |----------|-------------|---------|
-| `DD MMMM YYYY HH:mm` | Date with full month and time | `23 August 2024 10:30` |
 | `DD MMMM dddd, YYYY` | Date with weekday and comma | `23 August Friday, 2024` |
 | `YYYY MMM DD` | Year-month-day format | `2024 Aug 23` |
 | `YYYY MMMM DD` | Year-fullmonth-day format | `2024 August 23` |
@@ -330,7 +327,6 @@ date.format('YYYY-MM-DDTHH:mm:ss'); // '2024-08-23T10:30:45'
 ```javascript
 const date = new kk_date('2024-08-23 10:30:45');
 
-date.format('DD MMMM YYYY HH:mm');   // '23 August 2024 10:30'
 date.format('DD MMMM dddd, YYYY');   // '23 August Friday, 2024'
 date.format('YYYY MMM DD');          // '2024 Aug 23'
 date.format('YYYY MMMM DD');         // '2024 August 23'
@@ -342,59 +338,65 @@ date.format('YYYY MMMM DD');         // '2024 August 23'
 |----------|-------------|---------|
 | `YYYY-MM-DD HH:mm` | Compact datetime | `2024-08-23 10:30` |
 | `DD.MM.YYYY HH:mm` | European compact | `23.08.2024 10:30` |
-| `MM/DD/YYYY HH:mm` | US compact | `08/23/2024 10:30` |
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:45');
 
 date.format('YYYY-MM-DD HH:mm'); // '2024-08-23 10:30'
 date.format('DD.MM.YYYY HH:mm'); // '23.08.2024 10:30'
-date.format('MM/DD/YYYY HH:mm'); // '08/23/2024 10:30'
 ```
 
 ## Custom Formatting
 
-### Combining Templates
+> **Important:** `format()` matches the **whole** template string against a fixed set of supported patterns
+> (see the tables above). It does **not** interpolate tokens inside arbitrary text — passing an unsupported
+> string such as `'YYYY/MM/DD at HH:mm'` or `'Today is dddd'` throws `Error: template is not right`.
+> To build a custom string, format the pieces you need and combine them in JavaScript, or use `format_c()`.
 
-You can combine any templates to create custom formats:
+### Combining Templates with `format_c(separator, ...templates)`
+
+`format_c()` formats several supported templates and joins them with a separator:
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:45');
 
-// Custom formats
-date.format('YYYY/MM/DD at HH:mm');     // '2024/08/23 at 10:30'
-date.format('Today is dddd');           // 'Today is Friday'
-date.format('Time: HH:mm:ss on DD MMM'); // 'Time: 10:30:45 on 23 Aug'
+date.format_c(' ', 'YYYY-MM-DD', 'HH:mm:ss');           // '2024-08-23 10:30:45'
+date.format_c('T', 'YYYY-MM-DD', 'HH:mm:ss');            // '2024-08-23T10:30:45'
+date.format_c('-', 'DD', 'MM', 'YYYY');                  // '23-08-2024'
+date.format_c(' ', 'dddd, DD MMMM YYYY', 'HH:mm');       // 'Friday, 23 August 2024 10:30'
 ```
 
-### Special Characters
+### Building Strings with Surrounding Text
 
-You can include any characters in your format string:
+For labels or sentences, concatenate formatted parts in plain JavaScript:
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:45');
 
-date.format('Date: YYYY-MM-DD');        // 'Date: 2024-08-23'
-date.format('Time: HH:mm:ss');          // 'Time: 10:30:45'
-date.format('Created on DD/MM/YYYY');   // 'Created on 23/08/2024'
+`Date: ${date.format('YYYY-MM-DD')}`;        // 'Date: 2024-08-23'
+`Time: ${date.format('HH:mm:ss')}`;          // 'Time: 10:30:45'
+`Created on ${date.format('DD/MM/YYYY')}`;   // 'Created on 23/08/2024'
 ```
 
 ### Conditional Formatting
 
-You can create conditional formats based on date properties:
+Branch in JavaScript, then format the pieces you need:
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:45');
 
-// Different formats for different times
+// Different greetings for different times
 const hour = parseInt(date.format('HH'), 10);
+const time = date.format('HH:mm');
+let greeting;
 if (hour < 12) {
-    console.log(date.format('Good morning! It\'s HH:mm')); // 'Good morning! It's 10:30'
+    greeting = `Good morning! It's ${time}`;   // "Good morning! It's 10:30"
 } else if (hour < 18) {
-    console.log(date.format('Good afternoon! It\'s HH:mm')); // 'Good afternoon! It's 10:30'
+    greeting = `Good afternoon! It's ${time}`;
 } else {
-    console.log(date.format('Good evening! It\'s HH:mm')); // 'Good evening! It's 10:30'
+    greeting = `Good evening! It's ${time}`;
 }
+console.log(greeting);
 ```
 
 ## Locale Support
@@ -413,7 +415,7 @@ const date = new kk_date('2024-08-23 10:30:45');
 
 // Turkish month and weekday names
 date.format('DD MMMM YYYY'); // '23 Ağustos 2024'
-date.format('dddd, DD MMMM'); // 'Cuma, 23 Ağustos'
+date.format('dddd, DD MMMM YYYY'); // 'Cuma, 23 Ağustos 2024'
 ```
 
 ### Available Locales
@@ -447,12 +449,12 @@ locales.forEach(locale => {
     console.log(`${locale}: ${date.format('dddd, DD MMMM YYYY')}`);
 });
 
-// Output:
+// Output (weekday/month names come from Intl; fr/es return them lowercased):
 // en: Friday, 23 August 2024
 // tr: Cuma, 23 Ağustos 2024
 // de: Freitag, 23 August 2024
-// fr: Vendredi, 23 août 2024
-// es: Viernes, 23 agosto 2024
+// fr: vendredi, 23 août 2024
+// es: viernes, 23 agosto 2024
 ```
 
 
@@ -463,7 +465,7 @@ locales.forEach(locale => {
 #### 1. File Naming
 
 ```javascript
-const date = new kk_date();
+const date = new kk_date('2024-08-23 14:30:45'); // use new kk_date() for the current time
 
 // Create timestamped filenames
 const dateStr = date.format('YYYYMMDD');
@@ -499,7 +501,8 @@ const date = new kk_date('2024-08-23 10:30:45');
 // Display formats
 const displayDate = date.format('DD MMMM YYYY');
 const displayTime = date.format('HH:mm');
-const displayDateTime = date.format('dddd, DD MMMM YYYY at HH:mm');
+// 'at' is arbitrary text, so build the combined string in JS (format() has no token interpolation):
+const displayDateTime = `${date.format('dddd, DD MMMM YYYY')} at ${date.format('HH:mm')}`;
 
 console.log(`Date: ${displayDate}`);           // Date: 23 August 2024
 console.log(`Time: ${displayTime}`);           // Time: 10:30
@@ -518,7 +521,7 @@ const apiResponse = {
     created_at: date.format('YYYY-MM-DDTHH:mm:ss'),
     display_date: date.format('DD MMMM YYYY'),
     display_time: date.format('HH:mm'),
-    timestamp: date.getTime()
+    timestamp: date.getTime() // input parsed as UTC (see timezone note); system-timezone-dependent
 };
 
 console.log(JSON.stringify(apiResponse, null, 2));
@@ -528,7 +531,7 @@ console.log(JSON.stringify(apiResponse, null, 2));
 //   "created_at": "2024-08-23T10:30:45",
 //   "display_date": "23 August 2024",
 //   "display_time": "10:30",
-//   "timestamp": 1724407200000
+//   "timestamp": 1724409045000
 // }
 ```
 
@@ -550,10 +553,11 @@ console.log(`Event time: ${eventTime}`); // Event time: 10:30
 #### 6. Logging
 
 ```javascript
-const date = new kk_date();
+const date = new kk_date('2024-08-23 14:30:45.123'); // use new kk_date() for the current time
 
 // Log formats
-const logTimestamp = date.format('YYYY-MM-DD HH:mm:ss.SSS');
+// Note: there is no single 'YYYY-MM-DD HH:mm:ss.SSS' template — compose it with format_c().
+const logTimestamp = date.format_c(' ', 'YYYY-MM-DD', 'HH:mm:ss.SSS');
 const logDate = date.format('DD/MM/YYYY');
 const logTime = date.format('HH:mm:ss');
 
@@ -587,18 +591,19 @@ console.log(date.format(DATETIME_FORMAT));
 
 ### Error Handling
 
-The `format()` method handles invalid templates gracefully:
+The `format()` method **throws** on an unsupported template (`Error: template is not right`), so wrap
+untrusted templates in a try/catch:
 
 ```javascript
 const date = new kk_date('2024-08-23 10:30:45');
 
 try {
-    // Invalid template
+    // Unsupported template -> throws
     const result = date.format('INVALID_TEMPLATE');
     console.log(result);
 } catch (error) {
-    console.log('Format error:', error.message);
-    // Fallback to default format
+    console.log('Format error:', error.message); // 'template is not right'
+    // Fallback to a supported template
     console.log(date.format('YYYY-MM-DD HH:mm:ss'));
 }
 ```

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -384,11 +384,11 @@ node benchmark2.js  # Sequential operations benchmark
 <!-- BENCH:perf-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **309ms** | 1717ms | 971ms | 1266ms | **~214% faster** than Day.js |
-| **Time Operations** | **595ms** | 1960ms | 789ms | 3065ms | **~33% faster** than Day.js |
-| **Timezone Conversions** | **598ms** | 3677ms | 25507ms | 5650ms | **~515% faster** than Moment |
-| **Complex Operations** | **550ms** | 3626ms | 1852ms | 3798ms | **~237% faster** than Day.js |
-| **Overall** | **2.05s** | 10.98s | 29.12s | 13.78s | **~14.2x faster** than Day.js |
+| **Date Creation & Formatting** | **254ms** | 1545ms | 915ms | 1248ms | **~260% faster** than Day.js |
+| **Time Operations** | **548ms** | 1753ms | 730ms | 3162ms | **~33% faster** than Day.js |
+| **Timezone Conversions** | **474ms** | 3485ms | 23790ms | 5064ms | **~635% faster** than Moment |
+| **Complex Operations** | **489ms** | 3375ms | 1700ms | 3741ms | **~248% faster** than Day.js |
+| **Overall** | **1.76s** | 10.16s | 27.14s | 13.21s | **~15.4x faster** than Day.js |
 <!-- /BENCH:perf-seq -->
 
 #### Key Performance Metrics

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -384,11 +384,11 @@ node benchmark2.js  # Sequential operations benchmark
 <!-- BENCH:perf-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **272ms** | 1588ms | 922ms | 1239ms | **~239% faster** than Day.js |
-| **Time Operations** | **560ms** | 1743ms | 741ms | 3248ms | **~32% faster** than Day.js |
-| **Timezone Conversions** | **467ms** | 3503ms | 24013ms | 5054ms | **~650% faster** than Moment |
-| **Complex Operations** | **509ms** | 3426ms | 1720ms | 3808ms | **~238% faster** than Day.js |
-| **Overall** | **1.81s** | 10.26s | 27.40s | 13.35s | **~15.2x faster** than Day.js |
+| **Date Creation & Formatting** | **190ms** | 1128ms | 726ms | 905ms | **~281% faster** than Day.js |
+| **Time Operations** | **426ms** | 1256ms | 556ms | 2733ms | **~31% faster** than Day.js |
+| **Timezone Conversions** | **416ms** | 3285ms | 18959ms | 4450ms | **~690% faster** than Moment |
+| **Complex Operations** | **337ms** | 2510ms | 1230ms | 2920ms | **~265% faster** than Day.js |
+| **Overall** | **1.37s** | 8.18s | 21.47s | 11.01s | **~15.7x faster** than Day.js |
 <!-- /BENCH:perf-seq -->
 
 #### Key Performance Metrics
@@ -396,9 +396,9 @@ node benchmark2.js  # Sequential operations benchmark
 *Measured in our benchmark suite on Node.js 26 and reproduced by CI on every PR (the "Performance Benchmarks" job). These are not guarantees — results vary by workload, hardware, and Node version. Reproduce them with `node benchmark.js` / `node benchmark2.js`.*
 
 <!-- BENCH:perf-metrics -->
-- **~86% faster** than the average of competing libraries (comprehensive benchmark)
+- **~84% faster** than the average of competing libraries (comprehensive benchmark)
 - **up to ~98% faster** in timezone operations
-- **~69% faster** with caching enabled
+- **~72% faster** with caching enabled
 - **kk-date does not win every scenario** — Day.js is faster in isolated "Time Operations"
 - **Net memory delta is GC-dependent** (often negative for several libraries); stability comes from object pooling + LRU eviction
 - **Near-100% cache hit rate** for repeated operations

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,9 +8,11 @@ kk-date is designed for speed and efficiency, featuring intelligent caching, mem
 
 ## ⚡ Performance Features
 
-### Revolutionary Memory Management (Negative Memory Usage!)
+### Memory Management (can show negative net usage)
 
-kk-date achieves **negative memory usage** (-7.39 MB), meaning it actually cleans up more memory than it uses:
+> Net memory delta is a **GC-timing artifact**, not a guarantee — from run to run it can be **positive or negative**, and **several other libraries (e.g. Luxon) also show negative values**. It depends on workload, Node version, and GC behavior. Measure with `node benchmark.js`.
+
+In our benchmarks kk-date can report **negative net memory usage**, i.e. it frees more than it allocates during the measured run:
 
 **How it works:**
 - **Object Pooling**: Reuses existing objects instead of creating new ones
@@ -102,7 +104,8 @@ function benchmarkFormatting() {
         testDate.format('YYYY-MM-DD HH:mm:ss');
         testDate.format('DD.MM.YYYY');
         testDate.format('DD MMMM YYYY');
-        testDate.format('dddd, DD MMMM YYYY HH:mm');
+        // 'dddd, DD MMMM YYYY HH:mm' is not a single supported template — compose with format_c:
+        testDate.format_c(' ', 'dddd, DD MMMM YYYY', 'HH:mm');
     }
     console.timeEnd('Date Formatting');
 }
@@ -225,9 +228,10 @@ function benchmarkValidation() {
     
     console.time('Validation Operations');
     for (let i = 0; i < iterations; i++) {
+        // The static isValid() REQUIRES a format template (otherwise it throws 'Invalid template !').
         // Test valid inputs
         validInputs.forEach(input => {
-            kk_date.isValid(input);
+            kk_date.isValid(input, 'YYYY-MM-DD');
             try {
                 new kk_date(input).isValid();
             } catch (e) {}
@@ -235,7 +239,7 @@ function benchmarkValidation() {
         
         // Test invalid inputs
         invalidInputs.forEach(input => {
-            kk_date.isValid(input);
+            kk_date.isValid(input, 'YYYY-MM-DD');
             try {
                 new kk_date(input).isValid();
             } catch (e) {}
@@ -351,7 +355,7 @@ function monitorMemoryUsage() {
 function manageCacheMemory() {
     const stats = kk_date.caching_status();
     if (stats.cacheSize > 1000) { // Arbitrary threshold
-        kk_date.clearCache();
+        kk_date.caching_flush();
         console.log('Cache cleared due to size:', stats.cacheSize);
     }
 }
@@ -373,25 +377,30 @@ node benchmark.js   # Comprehensive benchmark
 node benchmark2.js  # Sequential operations benchmark
 ```
 
-### Latest Benchmark Results (December 2024)
+### Benchmark Results (representative run — reproduced by CI on every PR)
 
-#### Sequential Operations (1000 days, 100 ops/day)
+#### Sequential Operations (1000 days, 100 ops/day — 100,000 ops per scenario)
 
-| Operation | kk-date | Moment.js | Day.js | Luxon | Performance |
-|-----------|---------|-----------|--------|-------|--------------|
-| **Date Creation & Formatting** | **284ms** | 633ms | 464ms | 564ms | **63% faster** than Day.js |
-| **Time Operations** | **201ms** | 786ms | 399ms | 2196ms | **98% faster** than Day.js |
-| **Timezone Conversions** | **338ms** | 1231ms | 14806ms | 2836ms | **43x faster** than Day.js |
-| **Complex Operations** | **477ms** | 1469ms | 905ms | 2513ms | **90% faster** than Day.js |
-| **Overall** | **1.30s** | 4.12s | 16.57s | 8.11s | **11.75x faster** than Day.js |
+<!-- BENCH:perf-seq -->
+| Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
+|-----------|---------|-----------|--------|-------|-----------------------|
+| **Date Creation & Formatting** | **284ms** | 667ms | 487ms | 627ms | **~72% faster** than Day.js |
+| **Time Operations** | 439ms | 754ms | **357ms** | 1580ms | **~23% slower** than Day.js |
+| **Timezone Conversions** | **304ms** | 1085ms | 12586ms | 2314ms | **~257% faster** than Moment |
+| **Complex Operations** | **524ms** | 1318ms | 825ms | 1768ms | **~57% faster** than Day.js |
+| **Overall** | **1.55s** | 3.82s | 14.25s | 6.29s | **~9.2x faster** than Day.js |
+<!-- /BENCH:perf-seq -->
 
 #### Key Performance Metrics
 
-- **84.58% faster** than the average of competing libraries
-- **95-99% faster** in timezone operations
-- **74.55% performance improvement** with caching enabled
-- **Negative memory usage** (-7.39 MB) through intelligent object pooling
-- **100% cache hit rate** for repeated operations
+*Measured in our benchmark suite on Node.js 22 and reproduced by CI on every PR (the "Performance Benchmarks" job). These are not guarantees — results vary by workload, hardware, and Node version. Reproduce them with `node benchmark.js` / `node benchmark2.js`.*
+
+- **~80% faster** than the average of competing libraries (comprehensive benchmark)
+- **~95-99% faster** in timezone operations
+- **~70% faster** with caching enabled
+- **kk-date does not win every scenario** — Day.js is faster in isolated "Time Operations"
+- **Net memory delta is GC-dependent** (often negative for several libraries); stability comes from object pooling + LRU eviction
+- **Near-100% cache hit rate** for repeated operations
 
 ### Custom Benchmark Template
 
@@ -575,7 +584,7 @@ setInterval(() => {
    // Clear cache periodically in long-running processes
    setInterval(() => {
        if (kk_date.caching_status().cacheSize > 10000) {
-           kk_date.clearCache();
+           kk_date.caching_flush();
        }
    }, 3600000); // Every hour
    ```

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -384,23 +384,25 @@ node benchmark2.js  # Sequential operations benchmark
 <!-- BENCH:perf-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **254ms** | 1545ms | 915ms | 1248ms | **~260% faster** than Day.js |
-| **Time Operations** | **548ms** | 1753ms | 730ms | 3162ms | **~33% faster** than Day.js |
-| **Timezone Conversions** | **474ms** | 3485ms | 23790ms | 5064ms | **~635% faster** than Moment |
-| **Complex Operations** | **489ms** | 3375ms | 1700ms | 3741ms | **~248% faster** than Day.js |
-| **Overall** | **1.76s** | 10.16s | 27.14s | 13.21s | **~15.4x faster** than Day.js |
+| **Date Creation & Formatting** | **284ms** | 667ms | 487ms | 627ms | **~72% faster** than Day.js |
+| **Time Operations** | 439ms | 754ms | **357ms** | 1580ms | **~23% slower** than Day.js |
+| **Timezone Conversions** | **304ms** | 1085ms | 12586ms | 2314ms | **~257% faster** than Moment |
+| **Complex Operations** | **524ms** | 1318ms | 825ms | 1768ms | **~57% faster** than Day.js |
+| **Overall** | **1.55s** | 3.82s | 14.25s | 6.29s | **~9.2x faster** than Day.js |
 <!-- /BENCH:perf-seq -->
 
 #### Key Performance Metrics
 
 *Measured in our benchmark suite on Node.js 26 and reproduced by CI on every PR (the "Performance Benchmarks" job). These are not guarantees — results vary by workload, hardware, and Node version. Reproduce them with `node benchmark.js` / `node benchmark2.js`.*
 
-- **~80% faster** than the average of competing libraries (comprehensive benchmark)
-- **~95-99% faster** in timezone operations
-- **~70% faster** with caching enabled
+<!-- BENCH:perf-metrics -->
+- **~82% faster** than the average of competing libraries (comprehensive benchmark)
+- **up to ~98% faster** in timezone operations
+- **~69% faster** with caching enabled
 - **kk-date does not win every scenario** — Day.js is faster in isolated "Time Operations"
 - **Net memory delta is GC-dependent** (often negative for several libraries); stability comes from object pooling + LRU eviction
 - **Near-100% cache hit rate** for repeated operations
+<!-- /BENCH:perf-metrics -->
 
 ### Custom Benchmark Template
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -384,11 +384,11 @@ node benchmark2.js  # Sequential operations benchmark
 <!-- BENCH:perf-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **284ms** | 667ms | 487ms | 627ms | **~72% faster** than Day.js |
-| **Time Operations** | 439ms | 754ms | **357ms** | 1580ms | **~23% slower** than Day.js |
-| **Timezone Conversions** | **304ms** | 1085ms | 12586ms | 2314ms | **~257% faster** than Moment |
-| **Complex Operations** | **524ms** | 1318ms | 825ms | 1768ms | **~57% faster** than Day.js |
-| **Overall** | **1.55s** | 3.82s | 14.25s | 6.29s | **~9.2x faster** than Day.js |
+| **Date Creation & Formatting** | **272ms** | 1588ms | 922ms | 1239ms | **~239% faster** than Day.js |
+| **Time Operations** | **560ms** | 1743ms | 741ms | 3248ms | **~32% faster** than Day.js |
+| **Timezone Conversions** | **467ms** | 3503ms | 24013ms | 5054ms | **~650% faster** than Moment |
+| **Complex Operations** | **509ms** | 3426ms | 1720ms | 3808ms | **~238% faster** than Day.js |
+| **Overall** | **1.81s** | 10.26s | 27.40s | 13.35s | **~15.2x faster** than Day.js |
 <!-- /BENCH:perf-seq -->
 
 #### Key Performance Metrics
@@ -396,7 +396,7 @@ node benchmark2.js  # Sequential operations benchmark
 *Measured in our benchmark suite on Node.js 26 and reproduced by CI on every PR (the "Performance Benchmarks" job). These are not guarantees — results vary by workload, hardware, and Node version. Reproduce them with `node benchmark.js` / `node benchmark2.js`.*
 
 <!-- BENCH:perf-metrics -->
-- **~82% faster** than the average of competing libraries (comprehensive benchmark)
+- **~86% faster** than the average of competing libraries (comprehensive benchmark)
 - **up to ~98% faster** in timezone operations
 - **~69% faster** with caching enabled
 - **kk-date does not win every scenario** — Day.js is faster in isolated "Time Operations"

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -384,11 +384,11 @@ node benchmark2.js  # Sequential operations benchmark
 <!-- BENCH:perf-seq -->
 | Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |
 |-----------|---------|-----------|--------|-------|-----------------------|
-| **Date Creation & Formatting** | **284ms** | 667ms | 487ms | 627ms | **~72% faster** than Day.js |
-| **Time Operations** | 439ms | 754ms | **357ms** | 1580ms | **~23% slower** than Day.js |
-| **Timezone Conversions** | **304ms** | 1085ms | 12586ms | 2314ms | **~257% faster** than Moment |
-| **Complex Operations** | **524ms** | 1318ms | 825ms | 1768ms | **~57% faster** than Day.js |
-| **Overall** | **1.55s** | 3.82s | 14.25s | 6.29s | **~9.2x faster** than Day.js |
+| **Date Creation & Formatting** | **309ms** | 1717ms | 971ms | 1266ms | **~214% faster** than Day.js |
+| **Time Operations** | **595ms** | 1960ms | 789ms | 3065ms | **~33% faster** than Day.js |
+| **Timezone Conversions** | **598ms** | 3677ms | 25507ms | 5650ms | **~515% faster** than Moment |
+| **Complex Operations** | **550ms** | 3626ms | 1852ms | 3798ms | **~237% faster** than Day.js |
+| **Overall** | **2.05s** | 10.98s | 29.12s | 13.78s | **~14.2x faster** than Day.js |
 <!-- /BENCH:perf-seq -->
 
 #### Key Performance Metrics

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -393,7 +393,7 @@ node benchmark2.js  # Sequential operations benchmark
 
 #### Key Performance Metrics
 
-*Measured in our benchmark suite on Node.js 22 and reproduced by CI on every PR (the "Performance Benchmarks" job). These are not guarantees — results vary by workload, hardware, and Node version. Reproduce them with `node benchmark.js` / `node benchmark2.js`.*
+*Measured in our benchmark suite on Node.js 26 and reproduced by CI on every PR (the "Performance Benchmarks" job). These are not guarantees — results vary by workload, hardware, and Node version. Reproduce them with `node benchmark.js` / `node benchmark2.js`.*
 
 - **~80% faster** than the average of competing libraries (comprehensive benchmark)
 - **~95-99% faster** in timezone operations

--- a/docs/TESTING-GUIDE.md
+++ b/docs/TESTING-GUIDE.md
@@ -52,7 +52,7 @@ NODE_ENV=test npm test
 
 ## Test Structure
 
-### Test File Organization (322 Total Tests)
+### Test File Organization (499 Total Tests)
 
 ```
 test/
@@ -105,7 +105,7 @@ describe('Feature Name', () => {
         test('should throw error for invalid input', () => {
             expect(() => {
                 new kk_date('invalid-date');
-            }).toThrow('Invalid date format');
+            }).toThrow('Invalid Date');
         });
     });
 });
@@ -175,18 +175,20 @@ expect(date.getTime()).toBe(1724407200000);
 // Array assertions
 expect(['2024-08-23', '2024-08-24']).toContain(date.format('YYYY-MM-DD'));
 
-// Object assertions
+// Object assertions (getTimezoneInfo also returns standardOffset & daylightOffset)
 expect(date.getTimezoneInfo('America/New_York')).toEqual({
     timezone: 'America/New_York',
     offset: -14400000,
     isDST: true,
-    abbreviation: 'EDT'
+    abbreviation: 'EDT',
+    standardOffset: -18000000,
+    daylightOffset: -14400000
 });
 
 // Error assertions
 expect(() => {
     new kk_date('invalid-date');
-}).toThrow('Invalid date format');
+}).toThrow('Invalid Date');
 
 // Async assertions
 test('should handle async operations', async () => {
@@ -258,10 +260,11 @@ describe('Integration Tests', () => {
             const utcDate = new kk_date('2024-08-23 10:00:00');
             utcDate.config({timezone: 'UTC'});
 
-            // Convert to multiple timezones
-            const nyTime = utcDate.tz('America/New_York');
-            const tokyoTime = utcDate.tz('Asia/Tokyo');
-            const londonTime = utcDate.tz('Europe/London');
+            // Convert to multiple timezones.
+            // Use a fresh instance per conversion — .tz() mutates the instance it is called on.
+            const nyTime = new kk_date('2024-08-23 10:00:00').tz('America/New_York');
+            const tokyoTime = new kk_date('2024-08-23 10:00:00').tz('Asia/Tokyo');
+            const londonTime = new kk_date('2024-08-23 10:00:00').tz('Europe/London');
 
             // Verify conversions
             expect(nyTime.format('HH:mm')).toBe('06:00');
@@ -285,14 +288,14 @@ describe('Integration Tests', () => {
                 time: date.format('HH:mm:ss'),
                 datetime: date.format('YYYY-MM-DD HH:mm:ss'),
                 iso: date.format('YYYY-MM-DDTHH:mm:ss'),
-                custom: date.format('DD MMMM YYYY, dddd')
+                custom: date.format('DD MMMM dddd, YYYY')
             };
 
             expect(formats.date).toBe('2024-08-23');
             expect(formats.time).toBe('10:30:45');
             expect(formats.datetime).toBe('2024-08-23 10:30:45');
             expect(formats.iso).toBe('2024-08-23T10:30:45');
-            expect(formats.custom).toBe('23 August 2024, Friday');
+            expect(formats.custom).toBe('23 August Friday, 2024');
         });
     });
 });
@@ -304,13 +307,15 @@ describe('Integration Tests', () => {
 describe('Edge Cases', () => {
     describe('DST Transitions', () => {
         test('should handle spring forward', () => {
-            const dstDate = new kk_date('2024-03-10 02:00:00');
+            // 07:00 UTC on 2024-03-10 is just after New York springs forward to EDT.
+            const dstDate = new kk_date('2024-03-10T07:00:00.000Z');
             const nyTime = dstDate.tz('America/New_York');
             expect(nyTime.format('HH:mm')).toBe('03:00'); // EDT
         });
 
         test('should handle fall back', () => {
-            const dstDate = new kk_date('2024-11-03 02:00:00');
+            // 06:00 UTC on 2024-11-03 is exactly when New York falls back to EST.
+            const dstDate = new kk_date('2024-11-03T06:00:00.000Z');
             const nyTime = dstDate.tz('America/New_York');
             expect(nyTime.format('HH:mm')).toBe('01:00'); // EST
         });
@@ -338,7 +343,7 @@ describe('Edge Cases', () => {
         test('should handle invalid date string', () => {
             expect(() => {
                 new kk_date('not-a-date');
-            }).toThrow('Invalid date format');
+            }).toThrow('Invalid Date');
         });
     });
 
@@ -355,8 +360,10 @@ describe('Edge Cases', () => {
         });
 
         test('should handle non-leap years', () => {
+            // Feb 29 in a non-leap year is NOT rejected — it rolls over to March 1 and is valid.
             const nonLeapYear = new kk_date('2023-02-29 10:00:00');
-            expect(nonLeapYear.isValid()).toBe(false);
+            expect(nonLeapYear.isValid()).toBe(true);
+            expect(nonLeapYear.format('YYYY-MM-DD')).toBe('2023-03-01');
         });
     });
 });

--- a/docs/TIMEZONE-GUIDE.md
+++ b/docs/TIMEZONE-GUIDE.md
@@ -17,6 +17,11 @@ Comprehensive guide to timezone handling in kk-date, including DST support, conv
 
 kk-date provides comprehensive timezone support using the IANA timezone database. This ensures accurate timezone conversions, automatic DST handling, and cross-platform consistency.
 
+> **How to read the examples in this guide:**
+> - A **naive** string like `'2024-08-23 10:00:00'` is parsed in the **global/process timezone**. Examples that use naive inputs assume that timezone is **UTC** (`kk_date.setTimezone('UTC')` or `TZ=UTC`).
+> - `.tz()` and instance `config({ timezone })` change only the **display** timezone — they do **not** reinterpret the input string. To represent a specific zone's wall-clock time unambiguously, pass an **absolute instant** (ISO-8601 with `Z`/offset). Many examples below do exactly that (e.g. 2 PM New York = `2024-08-23T18:00:00.000Z`).
+> - `.tz()` **mutates** the instance and returns it — use a **fresh instance per conversion**.
+
 ### Key Features
 
 - **IANA Timezone Support**: Full support for all IANA timezone identifiers
@@ -32,14 +37,14 @@ kk-date provides comprehensive timezone support using the IANA timezone database
 ```javascript
 const kk_date = require('kk-date');
 
-// Set global default timezone
+// Set global default timezone (the most recent call wins)
 kk_date.setTimezone('UTC');
 kk_date.setTimezone('America/New_York');
 kk_date.setTimezone('Europe/London');
 
 // Get current global timezone
 const currentTimezone = kk_date.getTimezone();
-console.log(currentTimezone); // 'UTC'
+console.log(currentTimezone); // 'Europe/London' (the last value set)
 ```
 
 ### Converting Between Timezones
@@ -58,11 +63,12 @@ console.log(londonTime.format('HH:mm')); // '11:00' (BST)
 ### Instance-Specific Timezone
 
 ```javascript
-// Create date with specific timezone
+// Create a date, then display it in a specific timezone (global timezone = UTC)
 const date = new kk_date('2024-08-23 10:00:00');
 date.config({timezone: 'America/New_York'});
 
-console.log(date.format('HH:mm')); // '10:00' (interpreted as NY time)
+// config({ timezone }) only changes the DISPLAY zone; 10:00 UTC shown as New York local time:
+console.log(date.format('HH:mm')); // '06:00'
 ```
 
 ## DST (Daylight Saving Time)
@@ -72,15 +78,15 @@ console.log(date.format('HH:mm')); // '10:00' (interpreted as NY time)
 kk-date automatically handles DST transitions without any additional configuration:
 
 ```javascript
-// DST transition examples - separate instances for each conversion
+// DST is handled automatically. Absolute instants (…Z) show the transition unambiguously.
 
-// Spring forward (DST starts)
-const springTime = new kk_date('2024-03-10 02:00:00').tz('America/New_York');
-console.log(springTime.format('HH:mm')); // '03:00' (EDT)
+// New York springs forward at 07:00 UTC on 2024-03-10 (02:00 EST -> 03:00 EDT)
+console.log(new kk_date('2024-03-10T06:59:00.000Z').tz('America/New_York').format('HH:mm')); // '01:59' (EST)
+console.log(new kk_date('2024-03-10T07:00:00.000Z').tz('America/New_York').format('HH:mm')); // '03:00' (EDT)
 
-// Fall back (DST ends)
-const fallTime = new kk_date('2024-11-03 02:00:00').tz('America/New_York');
-console.log(fallTime.format('HH:mm')); // '01:00' (EST)
+// New York falls back at 06:00 UTC on 2024-11-03 (02:00 EDT -> 01:00 EST)
+console.log(new kk_date('2024-11-03T05:59:00.000Z').tz('America/New_York').format('HH:mm')); // '01:59' (EDT)
+console.log(new kk_date('2024-11-03T06:00:00.000Z').tz('America/New_York').format('HH:mm')); // '01:00' (EST)
 ```
 
 ### Checking DST Status
@@ -101,17 +107,13 @@ console.log(info.abbreviation); // 'EDT'
 ### DST Transition Dates
 
 ```javascript
-// 2024 DST transitions in US - separate instances for each operation
+// 2024 US spring-forward boundary (transition is at 07:00 UTC on 2024-03-10)
 
-// Before and after spring forward (separate instances)
-const beforeSpring = new kk_date('2024-03-10 02:00:00');
-beforeSpring.add(-1, 'hours');
-
-const afterSpring = new kk_date('2024-03-10 02:00:00');
-afterSpring.add(1, 'hours');
+const beforeSpring = new kk_date('2024-03-10T06:00:00.000Z'); // one hour before the transition
+const afterSpring  = new kk_date('2024-03-10T08:00:00.000Z'); // one hour after the transition
 
 console.log(beforeSpring.tz('America/New_York').format('HH:mm')); // '01:00' (EST)
-console.log(afterSpring.tz('America/New_York').format('HH:mm'));  // '03:00' (EDT)
+console.log(afterSpring.tz('America/New_York').format('HH:mm'));  // '04:00' (EDT)
 ```
 
 ## Timezone Conversion Examples
@@ -121,17 +123,17 @@ console.log(afterSpring.tz('America/New_York').format('HH:mm'));  // '03:00' (ED
 #### 1. International Meeting Scheduling
 
 ```javascript
-// Schedule a meeting at 2 PM New York time
-const meetingTime = new kk_date('2024-08-23 14:00:00');
-meetingTime.config({timezone: 'America/New_York'});
+// Schedule a meeting at 2 PM New York time. 2 PM EDT is 18:00 UTC — express it as an absolute instant
+// so every conversion is unambiguous (a fresh instance per .tz() call).
+const meetingInstant = '2024-08-23T18:00:00.000Z';
 
-// Convert to other timezones - separate instances for each conversion
-const londonTime = new kk_date('2024-08-23 14:00:00').config({timezone: 'America/New_York'}).tz('Europe/London');
-const tokyoTime = new kk_date('2024-08-23 14:00:00').config({timezone: 'America/New_York'}).tz('Asia/Tokyo');
-const sydneyTime = new kk_date('2024-08-23 14:00:00').config({timezone: 'America/New_York'}).tz('Australia/Sydney');
+const nyTime = new kk_date(meetingInstant).tz('America/New_York');
+const londonTime = new kk_date(meetingInstant).tz('Europe/London');
+const tokyoTime = new kk_date(meetingInstant).tz('Asia/Tokyo');
+const sydneyTime = new kk_date(meetingInstant).tz('Australia/Sydney');
 
 console.log('Meeting times:');
-console.log('New York:', meetingTime.format('HH:mm'));     // 14:00
+console.log('New York:', nyTime.format('HH:mm'));          // 14:00
 console.log('London:', londonTime.format('HH:mm'));        // 19:00
 console.log('Tokyo:', tokyoTime.format('HH:mm'));          // 03:00 (next day)
 console.log('Sydney:', sydneyTime.format('HH:mm'));        // 04:00 (next day)
@@ -140,17 +142,10 @@ console.log('Sydney:', sydneyTime.format('HH:mm'));        // 04:00 (next day)
 #### 2. Flight Departure Times
 
 ```javascript
-// Flight departs at 10:30 AM from Istanbul
-const departure = new kk_date('2024-08-23 10:30:00');
-departure.config({timezone: 'Europe/Istanbul'});
-
-// Flight arrives at 2:15 PM in New York
-const arrival = new kk_date('2024-08-23 14:15:00');
-arrival.config({timezone: 'America/New_York'});
-
-// Convert to UTC for storage - separate instances
-const departureUTC = new kk_date('2024-08-23 10:30:00').config({timezone: 'Europe/Istanbul'}).tz('UTC');
-const arrivalUTC = new kk_date('2024-08-23 14:15:00').config({timezone: 'America/New_York'}).tz('UTC');
+// Flight departs 10:30 in Istanbul (UTC+3 -> 07:30 UTC) and arrives 14:15 in New York (EDT -> 18:15 UTC).
+// Express each local time as its absolute UTC instant.
+const departureUTC = new kk_date('2024-08-23T07:30:00.000Z').tz('UTC');
+const arrivalUTC   = new kk_date('2024-08-23T18:15:00.000Z').tz('UTC');
 
 console.log('Flight times (UTC):');
 console.log('Departure:', departureUTC.format('HH:mm')); // 07:30
@@ -160,34 +155,27 @@ console.log('Arrival:', arrivalUTC.format('HH:mm'));     // 18:15
 #### 3. E-commerce Order Processing
 
 ```javascript
-// Order placed at 3:45 PM in customer's timezone (Los Angeles)
-const orderTime = new kk_date('2024-08-23 15:45:00');
-orderTime.config({timezone: 'America/Los_Angeles'});
+// Order placed at 3:45 PM in Los Angeles (PDT -> 22:45 UTC). Use the absolute instant.
+const orderInstant = '2024-08-23T22:45:00.000Z';
 
-// Convert to warehouse timezone (Chicago) - separate instance
-const warehouseTime = new kk_date('2024-08-23 15:45:00').config({timezone: 'America/Los_Angeles'}).tz('America/Chicago');
+// Convert to warehouse timezone (Chicago)
+const warehouseTime = new kk_date(orderInstant).tz('America/Chicago');
 console.log('Order received at warehouse:', warehouseTime.format('HH:mm')); // 17:45
 
-// Convert to customer support timezone (India) - separate instance
-const supportTime = new kk_date('2024-08-23 15:45:00').config({timezone: 'America/Los_Angeles'}).tz('Asia/Kolkata');
-console.log('Order time for support:', supportTime.format('HH:mm')); // 04:15 (next day)
+// Convert to customer support timezone (India)
+const supportTime = new kk_date(orderInstant).tz('Asia/Kolkata');
+console.log('Order time for support:', supportTime.format('YYYY-MM-DD HH:mm')); // 2024-08-24 04:15 (next day)
 ```
 
 ### Cross-Day Conversions
 
 ```javascript
-// Late night in one timezone, early morning in another
-const lateNight = new kk_date('2024-08-23 23:30:00');
-lateNight.config({timezone: 'America/Los_Angeles'});
-
-const tokyoTime = new kk_date('2024-08-23 23:30:00').config({timezone: 'America/Los_Angeles'}).tz('Asia/Tokyo');
+// Late night in Los Angeles (23:30 PDT on 2024-08-23 -> 06:30 UTC on 2024-08-24)
+const tokyoTime = new kk_date('2024-08-24T06:30:00.000Z').tz('Asia/Tokyo');
 console.log(tokyoTime.format('YYYY-MM-DD HH:mm')); // 2024-08-24 15:30
 
-// Early morning in one timezone, late night in another
-const earlyMorning = new kk_date('2024-08-24 06:00:00');
-earlyMorning.config({timezone: 'Asia/Tokyo'});
-
-const laTime = new kk_date('2024-08-24 06:00:00').config({timezone: 'Asia/Tokyo'}).tz('America/Los_Angeles');
+// Early morning in Tokyo (06:00 on 2024-08-24 JST -> 21:00 UTC on 2024-08-23)
+const laTime = new kk_date('2024-08-23T21:00:00.000Z').tz('America/Los_Angeles');
 console.log(laTime.format('YYYY-MM-DD HH:mm')); // 2024-08-23 14:00
 ```
 
@@ -217,11 +205,12 @@ Instance configuration overrides global settings:
 // Global timezone is UTC
 kk_date.setTimezone('UTC');
 
-// Instance with specific timezone
+// Instance with specific DISPLAY timezone
 const nyDate = new kk_date('2024-08-23 10:00:00');
 nyDate.config({timezone: 'America/New_York'});
 
-console.log(nyDate.format('HH:mm')); // '10:00' (NY time, not UTC)
+// 10:00 UTC displayed in New York (config({ timezone }) sets the display zone, not the input zone):
+console.log(nyDate.format('HH:mm')); // '06:00'
 ```
 
 ### Configuration Priority
@@ -234,12 +223,12 @@ console.log(nyDate.format('HH:mm')); // '10:00' (NY time, not UTC)
 // Global: UTC
 kk_date.setTimezone('UTC');
 
-// Instance: New York
+// Instance: display in New York
 const date = new kk_date('2024-08-23 10:00:00');
 date.config({timezone: 'America/New_York'});
 
-// Result: Uses New York timezone (instance overrides global)
-console.log(date.format('HH:mm')); // '10:00' (NY time)
+// Result: 10:00 UTC displayed in New York (instance display zone overrides global)
+console.log(date.format('HH:mm')); // '06:00'
 ```
 
 ## Common Timezone Scenarios
@@ -249,45 +238,35 @@ console.log(date.format('HH:mm')); // '10:00' (NY time)
 ```javascript
 // Store user's preferred timezone
 kk_date.setUserTimezone('America/New_York');
+kk_date.setTimezone('UTC'); // server works in UTC
 
-// Use user timezone for display
-const serverTime = new kk_date('2024-08-23 15:00:00');
-serverTime.config({timezone: 'UTC'});
-
-const userTime = serverTime.tz(kk_date.getUserTimezone());
+// Convert a fresh instance to the user's timezone for display
+const userTime = new kk_date('2024-08-23 15:00:00').tz(kk_date.getUserTimezone());
 console.log('Time for user:', userTime.format('HH:mm')); // '11:00'
 ```
 
 ### 2. Database Storage
 
 ```javascript
-// Always store in UTC
-const userInput = '2024-08-23 14:30:00';
-const userTimezone = 'America/Chicago';
-
-// Parse user input in their timezone
-const userDate = new kk_date(userInput);
-userDate.config({timezone: userTimezone});
-
-// Convert to UTC for storage
-const utcDate = userDate.tz('UTC');
+// Always store in UTC. To interpret user input as a specific zone's wall-clock time, build the
+// absolute instant for that zone. 14:30 in America/Chicago (CDT, UTC-5) is 19:30 UTC.
+const utcDate = new kk_date('2024-08-23T19:30:00.000Z');
 console.log('Store in database:', utcDate.toISOString()); // '2024-08-23T19:30:00.000Z'
 ```
 
 ### 3. API Responses
 
 ```javascript
-// Server time in UTC
-const serverTime = new kk_date('2024-08-23 15:00:00');
-serverTime.config({timezone: 'UTC'});
+// Server time as an absolute UTC instant
+const serverTime = new kk_date('2024-08-23T15:00:00.000Z');
 
-// Convert to client's timezone for API response
+// Convert to client's timezone for the API response (fresh instance for the conversion)
 const clientTimezone = 'Europe/London';
-const clientTime = new kk_date('2024-08-23 15:00:00').config({timezone: 'UTC'}).tz(clientTimezone);
+const clientTime = new kk_date('2024-08-23T15:00:00.000Z').tz(clientTimezone);
 
 const apiResponse = {
-    serverTime: serverTime.toISOString(),
-    clientTime: clientTime.format('YYYY-MM-DD HH:mm:ss'),
+    serverTime: serverTime.toISOString(),               // '2024-08-23T15:00:00.000Z'
+    clientTime: clientTime.format('YYYY-MM-DD HH:mm:ss'), // '2024-08-23 16:00:00' (BST)
     timezone: clientTimezone
 };
 ```
@@ -295,11 +274,10 @@ const apiResponse = {
 ### 4. Calendar Applications
 
 ```javascript
-// Event at 2 PM in organizer's timezone
-const eventTime = new kk_date('2024-08-23 14:00:00');
-eventTime.config({timezone: 'America/New_York'});
+// Event at 2 PM in the organizer's timezone (New York, EDT) = 18:00 UTC
+const eventInstant = '2024-08-23T18:00:00.000Z';
 
-// Convert for different attendees
+// Convert for different attendees (a fresh instance per conversion)
 const attendees = [
     { name: 'John', timezone: 'Europe/London' },
     { name: 'Sarah', timezone: 'Asia/Tokyo' },
@@ -307,7 +285,7 @@ const attendees = [
 ];
 
 attendees.forEach(attendee => {
-    const localTime = new kk_date('2024-08-23 14:00:00').config({timezone: 'America/New_York'}).tz(attendee.timezone);
+    const localTime = new kk_date(eventInstant).tz(attendee.timezone);
     console.log(`${attendee.name}: ${localTime.format('HH:mm')}`);
 });
 // John: 19:00
@@ -320,12 +298,8 @@ attendees.forEach(attendee => {
 ### 1. Always Store in UTC
 
 ```javascript
-// ❌ Don't store local times
-const localTime = new kk_date('2024-08-23 14:00:00');
-localTime.config({timezone: 'America/New_York'});
-
-// ✅ Store in UTC
-const utcTime = new kk_date('2024-08-23 14:00:00').config({timezone: 'America/New_York'}).tz('UTC');
+// ✅ Store an absolute UTC instant. 2 PM New York (EDT) is 18:00 UTC.
+const utcTime = new kk_date('2024-08-23T18:00:00.000Z');
 console.log(utcTime.toISOString()); // '2024-08-23T18:00:00.000Z'
 ```
 
@@ -483,7 +457,7 @@ Common error messages and their solutions:
 
 - **"Invalid timezone: [timezone]"**: Use a valid IANA timezone identifier
 - **"Could not determine timezone offset"**: The timezone may not be supported in your environment
-- **"Invalid date format"**: Check your date input format
+- **"Invalid Date"**: Check your date input format
 
 ### Getting Help
 

--- a/functions.js
+++ b/functions.js
@@ -85,12 +85,12 @@ function getTimezoneOffset(timezone, date = new Date()) {
 	// Validate timezone first (outside try-catch for proper error handling)
 	checkTimezone(timezone);
 
-	// Check cache first
+	// Check cache first (single lookup)
 	const cacheKey = `${timezone}_${date.getTime()}`;
-	if (timezone_cache.has(cacheKey)) {
-		const { offset, timestamp } = timezone_cache.get(cacheKey);
-		if (date.getTime() - timestamp < cache_ttl) {
-			return offset;
+	const cachedOffset = timezone_cache.get(cacheKey);
+	if (cachedOffset !== undefined) {
+		if (date.getTime() - cachedOffset.timestamp < cache_ttl) {
+			return cachedOffset.offset;
 		}
 	}
 
@@ -611,30 +611,28 @@ function converter(date, to, options = { pad: true }) {
 		targetTimezone = orj_this.temp_config.timezone || global_config.timezone;
 	}
 
-	// Create cache key for this specific conversion
 	const timestamp = date.getTime();
-	const cacheKey = `${timestamp}_${to.join(',')}_${shouldPad}_${isUTC}_${targetTimezone || 'none'}_${detectedFormat || 'none'}`;
 
-	// Check cache first
-	if (converter_results_cache.has(cacheKey)) {
-		return converter_results_cache.get(cacheKey);
-	}
-
-	// Limit cache size to prevent memory leaks
-	if (converter_results_cache.size > 10000) {
-		// Clear half of the cache when limit is reached
-		const keysToDelete = Array.from(converter_results_cache.keys()).slice(0, 5000);
-		for (const key of keysToDelete) {
-			converter_results_cache.delete(key);
+	// Timezone-aware (Intl) path — taken only when a real zone conversion is needed: a non-UTC
+	// target that differs from the machine zone, a UTC instant (isUTC/ISO8601) that must be
+	// display-converted, or an 'Xx' timestamp (needs the '24'->'00' handling below). When the
+	// target equals the system zone for a local wall-clock date, the native getHours()/getMonth()
+	// accessors already yield identical output far more cheaply, so we fall through to the native
+	// path — which skips the cache entirely (distinct-timestamp workloads never reuse it, and
+	// repeated calls are already memoized upstream by formatter_cache).
+	if (targetTimezone && targetTimezone !== 'UTC' && (targetTimezone !== systemTimezone || isUTC || detectedFormat === 'Xx')) {
+		// Cache only this (expensive) Intl path.
+		const cacheKey = `${timestamp}_${to.join(',')}_${shouldPad}_${isUTC}_${targetTimezone}_${detectedFormat || 'none'}`;
+		const cachedResult = converter_results_cache.get(cacheKey);
+		if (cachedResult !== undefined) {
+			return cachedResult;
 		}
-	}
+		if (converter_results_cache.size > 10000) {
+			converter_results_cache.clear();
+		}
 
-	const result = {};
-
-	// Use timezone-aware formatting if targetTimezone is specified and not UTC
-	// For ISO8601 UTC timestamps with .tz() calls, we also need timezone formatting
-	if (targetTimezone && targetTimezone !== 'UTC') {
 		// Use Intl.DateTimeFormat for timezone-aware formatting
+		const result = {};
 		let formatter = null;
 		const partsMap = {};
 
@@ -695,8 +693,9 @@ function converter(date, to, options = { pad: true }) {
 		return result;
 	}
 
-	// Fast path: Use direct Date methods for most cases
+	// Native fast path — no cache: recompute is a handful of getters, cheaper than keying the cache.
 	if (detectedFormat !== 'Xx' || !global_config.timezone || global_config.timezone === 'UTC') {
+		const result = {};
 		// Standard formatting - much faster
 		const len = to.length;
 		for (let i = 0; i < len; i++) {
@@ -737,11 +736,20 @@ function converter(date, to, options = { pad: true }) {
 				}
 			}
 		}
-		converter_results_cache.set(cacheKey, result);
 		return result;
 	}
 
-	// Timezone-aware formatting only when absolutely necessary
+	// Timezone-aware fallback ('Xx' with a non-UTC global tz and an explicit UTC target).
+	// Cached — formatToParts is expensive.
+	const result = {};
+	const cacheKey = `${timestamp}_${to.join(',')}_${shouldPad}_${isUTC}_${targetTimezone || 'none'}_${detectedFormat || 'none'}`;
+	const cachedFallback = converter_results_cache.get(cacheKey);
+	if (cachedFallback !== undefined) {
+		return cachedFallback;
+	}
+	if (converter_results_cache.size > 10000) {
+		converter_results_cache.clear();
+	}
 	const useTimezone = targetTimezone || global_config.timezone;
 
 	// Cache the DateTimeFormat instance for performance

--- a/index.js
+++ b/index.js
@@ -738,6 +738,13 @@ class KkDate {
 					dateToModify.setDate(dateToModify.getDate() + defined_amount);
 				}
 				break;
+			case 'weeks':
+				if (targetTimezone) {
+					dateToModify.setUTCDate(dateToModify.getUTCDate() + defined_amount * 7);
+				} else {
+					dateToModify.setDate(dateToModify.getDate() + defined_amount * 7);
+				}
+				break;
 			case 'minutes':
 				if (targetTimezone) {
 					dateToModify.setUTCMinutes(dateToModify.getUTCMinutes() + defined_amount);
@@ -2117,10 +2124,6 @@ function config(options) {
 			cached_dateTimeFormat.MMM = new Intl.DateTimeFormat(global_config.locale, {
 				month: 'short',
 			});
-			if (typeof options.weekStartDay === 'number') {
-				isValidWeekStartDay(options.weekStartDay);
-				global_config.weekStartDay = options.weekStartDay;
-			}
 			if (typeof Intl?.RelativeTimeFormat === 'function') {
 				try {
 					global_config.rtf[global_config.locale] = new Intl.RelativeTimeFormat(global_config.locale, { numeric: 'auto' });
@@ -2131,6 +2134,10 @@ function config(options) {
 		}
 	} catch (error) {
 		throw new Error(error.message || 'locale not valid for BCP 47 / config');
+	}
+	if (typeof options.weekStartDay === 'number') {
+		isValidWeekStartDay(options.weekStartDay);
+		global_config.weekStartDay = options.weekStartDay;
 	}
 	if (options.timezone && global_config.timezone !== options.timezone) {
 		checkTimezone(options.timezone);

--- a/index.js
+++ b/index.js
@@ -22,13 +22,55 @@ const {
 	timeInMilliseconds,
 	format_types_regex,
 	global_config,
-	format_types_cache,
 	format_types_regex_cache,
 	formatter_cache
 } = require('./constants');
 
 
 nopeRedis.config({ defaultTtl: 1300 });
+
+// Mirrors nope-redis service status. When caching is disabled (the default), we skip all
+// cache reads/writes so no cache-key string, Date clone, or Promise is allocated on the hot path.
+let cachingEnabled = false;
+
+/**
+ * Builds a local-time Date from already-split numeric date parts using the numeric Date
+ * constructor, which skips the engine's (much slower) string date parser.
+ *
+ * Guarded on a 4-digit year: the parse regexes' `(|17|18|19|20|21)\d\d` empty-alternative also
+ * matches 2-digit years, for which the numeric constructor maps to 19xx and would accept inputs
+ * that the legacy string form rejects. 2-digit years fall back to the exact legacy string so
+ * behavior is preserved.
+ *
+ * @param {string} year
+ * @param {string} month - 1-based month
+ * @param {string} day
+ * @returns {Date}
+ */
+function fastLocalDate(year, month, day) {
+	if (year.length === 4) {
+		return new Date(+year, +month - 1, +day, 0, 0, 0, 0);
+	}
+	return new Date(`${year}-${month}-${day} 00:00:00`);
+}
+
+/**
+ * Like {@link fastLocalDate} but with a time component. `timePart` is the raw "HH:mm[:ss]" slice;
+ * seconds default to 0 when absent. Same 4-digit-year guard and legacy fallback.
+ *
+ * @param {string} year
+ * @param {string} month - 1-based month
+ * @param {string} day
+ * @param {string} timePart - "HH:mm" or "HH:mm:ss"
+ * @returns {Date}
+ */
+function fastLocalDateTime(year, month, day, timePart) {
+	if (year.length === 4) {
+		const [h, mi, s] = timePart.split(':');
+		return new Date(+year, +month - 1, +day, +h, +mi || 0, +s || 0, 0);
+	}
+	return new Date(`${year}-${month}-${day}T${timePart}`);
+}
 
 /**
  * @class KkDate
@@ -60,7 +102,9 @@ class KkDate {
 		} else {
 			const date = params[0];
 			let forced_format_founded = false;
-			cached = nopeRedis.getItem(date instanceof Date || Number.isInteger(date) ? null : `${date}`);
+			if (cachingEnabled) {
+				cached = nopeRedis.getItem(date instanceof Date || Number.isInteger(date) ? null : `${date}`);
+			}
 			if (typeof params[1] === 'string' && !cached) {
 				if (!format_types_regex[params[1]]) {
 					throw new Error(`Unsupported Format! ${params[1]} !`);
@@ -71,13 +115,13 @@ class KkDate {
 				if (params[1] === format_types['YYYY-DD-MM']) {
 					is_can_cache = true;
 					const [year, day, month] = date.split('-');
-					this.date = new Date(`${year}-${month}-${day} 00:00:00`);
+					this.date = fastLocalDate(year, month, day);
 					forced_format_founded = true;
 					this.detected_format = 'YYYY-DD-MM';
 				} else if (params[1] === format_types['YYYY-MM-DD']) {
 					is_can_cache = true;
 					const [year, month, day] = date.split('-');
-					this.date = new Date(`${year}-${month}-${day} 00:00:00`);
+					this.date = fastLocalDate(year, month, day);
 					forced_format_founded = true;
 					this.detected_format = 'YYYY-MM-DD';
 				}
@@ -106,17 +150,22 @@ class KkDate {
 					this.detected_format = 'now';
 				} else if (isValid(date, format_types['YYYY-MM-DD'])) {
 					const [year, month, day] = date.split('-');
-					this.date = new Date(`${year}-${month}-${day} 00:00:00`);
+					this.date = fastLocalDate(year, month, day);
 					this.detected_format = 'YYYY-MM-DD';
 				} else {
 					is_can_cache = true;
+					// Time-only formats are all <= 15 chars ("hh:mm:ss.SSS AM"); any longer string is a
+					// date/datetime, so skip the six time-format regex tests for it. The typeof guard keeps
+					// non-string inputs (e.g. null) falling through to the invalid-date fallback below.
 					if (
-						isValid(date, format_types['HH:mm:ss.SSS']) ||
-						isValid(date, format_types['HH:mm:ss']) ||
-						isValid(date, format_types['HH:mm']) ||
-						isValid(date, format_types['hh:mm']) ||
-						isValid(date, format_types['hh:mm:ss']) ||
-						isValid(date, format_types['hh:mm:ss.SSS'])
+						typeof date === 'string' &&
+						date.length <= 15 &&
+						(isValid(date, format_types['HH:mm:ss.SSS']) ||
+							isValid(date, format_types['HH:mm:ss']) ||
+							isValid(date, format_types['HH:mm']) ||
+							isValid(date, format_types['hh:mm']) ||
+							isValid(date, format_types['hh:mm:ss']) ||
+							isValid(date, format_types['hh:mm:ss.SSS']))
 					) {
 						let [hours, minutes, seconds] = date.split(':').map((n) => parseInt(n, 10));
 						const milliseconds = parseInt(date.split('.')[1] || 0, 10);
@@ -171,6 +220,13 @@ class KkDate {
 						if (typeof date === 'string' && date.includes('T') && date.endsWith('Z')) {
 							this.date = new Date(date);
 							this.detected_format = 'ISO8601';
+						} else if (typeof date === 'string' && date.charCodeAt(4) === 45 && date.charCodeAt(7) === 45 && date.charCodeAt(10) === 84) {
+							// ISO datetime without a Z/offset suffix, matched precisely by shape "____-__-__T…"
+							// (dashes at index 4 & 7, 'T' at 10) so weekday-name inputs like "Tuesday, …" are not
+							// caught. No ladder format uses a 'T' date/time separator, so these previously fell all
+							// the way through to the new Date(`${date}`) fallback; short-circuit to the identical
+							// parse (detected_format stays null, matching the old behavior).
+							this.date = new Date(date);
 						} else if (isValid(date, format_types['DD.MM.YYYY HH:mm:ss'])) {
 							const [datePart, timePart] = date.split(' ');
 							const [day, month, year] = datePart.split('.');
@@ -178,7 +234,7 @@ class KkDate {
 							if (hours >= 24) {
 								const extraDays = Math.floor(hours / 24);
 
-								const dateObj = new Date(`${year}-${month}-${day} 00:00:00`);
+								const dateObj = fastLocalDate(year, month, day);
 								dateObj.setDate(dateObj.getDate() + extraDays);
 
 								const newDay = String(dateObj.getDate()).padStart(2, '0');
@@ -189,7 +245,7 @@ class KkDate {
 									`${newYear}-${newMonth}-${newDay}T${(hours % 24).toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`,
 								);
 							} else {
-								this.date = new Date(`${year}-${month}-${day}T${timePart}`);
+								this.date = fastLocalDateTime(year, month, day, timePart);
 							}
 							this.detected_format = format_types['DD.MM.YYYY HH:mm:ss'];
 						} else if (isValid(date, format_types['DD.MM.YYYY HH:mm'])) {
@@ -199,7 +255,7 @@ class KkDate {
 							if (hours >= 24) {
 								const extraDays = Math.floor(hours / 24);
 
-								const dateObj = new Date(`${year}-${month}-${day} 00:00:00`);
+								const dateObj = fastLocalDate(year, month, day);
 								dateObj.setDate(dateObj.getDate() + extraDays);
 
 								const newDay = String(dateObj.getDate()).padStart(2, '0');
@@ -210,12 +266,12 @@ class KkDate {
 									`${newYear}-${newMonth}-${newDay}T${(hours % 24).toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`,
 								);
 							} else {
-								this.date = new Date(`${year}-${month}-${day}T${timePart}`);
+								this.date = fastLocalDateTime(year, month, day, timePart);
 							}
 							this.detected_format = format_types['DD.MM.YYYY HH:mm'];
 						} else if (isValid(date, format_types['DD.MM.YYYY'])) {
 							const [day, month, year] = date.split('.');
-							this.date = new Date(`${year}-${month}-${day} 00:00:00`);
+							this.date = fastLocalDate(year, month, day);
 							this.detected_format = format_types['DD.MM.YYYY'];
 						} else if (isValid(date, format_types['YYYY-MM-DD HH:mm:ss'])) {
 							const [datePart, timePart] = date.split(' ');
@@ -223,7 +279,7 @@ class KkDate {
 							const [hours, minutes, seconds] = timePart.split(':').map(Number);
 							if (hours >= 24) {
 								const extraDays = Math.floor(hours / 24);
-								const dateObj = new Date(`${year}-${month}-${day} 00:00:00`);
+								const dateObj = fastLocalDate(year, month, day);
 								dateObj.setDate(dateObj.getDate() + extraDays);
 
 								const newDay = String(dateObj.getDate()).padStart(2, '0');
@@ -234,7 +290,7 @@ class KkDate {
 									`${newYear}-${newMonth}-${newDay}T${(hours % 24).toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`,
 								);
 							} else {
-								this.date = new Date(`${year}-${month}-${day}T${timePart}`);
+								this.date = fastLocalDateTime(year, month, day, timePart);
 							}
 							this.detected_format = format_types['YYYY-MM-DD HH:mm:ss'];
 						} else if (isValid(date, format_types['YYYY-MM-DD HH:mm'])) {
@@ -243,7 +299,7 @@ class KkDate {
 							const [hours, minutes] = timePart.split(':').map(Number);
 							if (hours >= 24) {
 								const extraDays = Math.floor(hours / 24);
-								const dateObj = new Date(`${year}-${month}-${day} 00:00:00`);
+								const dateObj = fastLocalDate(year, month, day);
 								dateObj.setDate(dateObj.getDate() + extraDays);
 
 								const newDay = String(dateObj.getDate()).padStart(2, '0');
@@ -254,7 +310,7 @@ class KkDate {
 									`${newYear}-${newMonth}-${newDay}T${(hours % 24).toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`,
 								);
 							} else {
-								this.date = new Date(`${year}-${month}-${day}T${timePart}`);
+								this.date = fastLocalDateTime(year, month, day, timePart);
 							}
 							this.detected_format = format_types['YYYY-MM-DD HH:mm'];
 						} else if (isValid(date, format_types['YYYY.MM.DD HH:mm:ss'])) {
@@ -264,7 +320,7 @@ class KkDate {
 							if (hours >= 24) {
 								const extraDays = Math.floor(hours / 24);
 
-								const dateObj = new Date(`${year}-${month}-${day} 00:00:00`);
+								const dateObj = fastLocalDate(year, month, day);
 								dateObj.setDate(dateObj.getDate() + extraDays);
 
 								const newDay = String(dateObj.getDate()).padStart(2, '0');
@@ -275,7 +331,7 @@ class KkDate {
 									`${newYear}-${newMonth}-${newDay}T${(hours % 24).toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`,
 								);
 							} else {
-								this.date = new Date(`${year}-${month}-${day}T${timePart}`);
+								this.date = fastLocalDateTime(year, month, day, timePart);
 							}
 							this.detected_format = format_types['YYYY.MM.DD HH:mm:ss'];
 						} else if (isValid(date, format_types['YYYY.MM.DD HH:mm'])) {
@@ -285,7 +341,7 @@ class KkDate {
 							if (hours >= 24) {
 								const extraDays = Math.floor(hours / 24);
 
-								const dateObj = new Date(`${year}-${month}-${day} 00:00:00`);
+								const dateObj = fastLocalDate(year, month, day);
 								dateObj.setDate(dateObj.getDate() + extraDays);
 
 								const newDay = String(dateObj.getDate()).padStart(2, '0');
@@ -296,12 +352,12 @@ class KkDate {
 									`${newYear}-${newMonth}-${newDay}T${(hours % 24).toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`,
 								);
 							} else {
-								this.date = new Date(`${year}-${month}-${day}T${timePart}`);
+								this.date = fastLocalDateTime(year, month, day, timePart);
 							}
 							this.detected_format = format_types['YYYY.MM.DD HH:mm'];
 						} else if (isValid(date, format_types['DD-MM-YYYY'])) {
 							const [day, month, year] = date.split('-');
-							this.date = new Date(`${year}-${month}-${day} 00:00:00`);
+							this.date = fastLocalDate(year, month, day);
 							this.detected_format = format_types['DD-MM-YYYY'];
 						} else if (isValid(date, format_types['DD-MM-YYYY HH:mm:ss'])) {
 							const [datePart, timePart] = date.split(' ');
@@ -310,7 +366,7 @@ class KkDate {
 							if (hours >= 24) {
 								const extraDays = Math.floor(hours / 24);
 
-								const dateObj = new Date(`${year}-${month}-${day} 00:00:00`);
+								const dateObj = fastLocalDate(year, month, day);
 								dateObj.setDate(dateObj.getDate() + extraDays);
 
 								const newDay = String(dateObj.getDate()).padStart(2, '0');
@@ -321,7 +377,7 @@ class KkDate {
 									`${newYear}-${newMonth}-${newDay}T${(hours % 24).toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`,
 								);
 							} else {
-								this.date = new Date(`${year}-${month}-${day}T${timePart}`);
+								this.date = fastLocalDateTime(year, month, day, timePart);
 							}
 							this.detected_format = format_types['DD-MM-YYYY HH:mm:ss'];
 						} else if (isValid(date, format_types['DD-MM-YYYY HH:mm'])) {
@@ -331,7 +387,7 @@ class KkDate {
 							if (hours >= 24) {
 								const extraDays = Math.floor(hours / 24);
 
-								const dateObj = new Date(`${year}-${month}-${day} 00:00:00`);
+								const dateObj = fastLocalDate(year, month, day);
 								dateObj.setDate(dateObj.getDate() + extraDays);
 
 								const newDay = String(dateObj.getDate()).padStart(2, '0');
@@ -342,7 +398,7 @@ class KkDate {
 									`${newYear}-${newMonth}-${newDay}T${(hours % 24).toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`,
 								);
 							} else {
-								this.date = new Date(`${year}-${month}-${day}T${timePart}`);
+								this.date = fastLocalDateTime(year, month, day, timePart);
 							}
 							this.detected_format = format_types['DD-MM-YYYY HH:mm'];
 						} else if (isValid(date, format_types['DD MMMM YYYY'])) {
@@ -365,11 +421,14 @@ class KkDate {
 							const year = String(date.substring(0, 4), 10); // Extract year
 							const month = String(date.substring(4, 6), 10); // Extract month
 							const day = String(date.substring(6, 8), 10); // Extract day
-							this.date = new Date(`${year}-${month}-${day} 00:00:00`);
+							// substring() always yields a 4-char year, so guard on the full 8-char input:
+							// a short (2-digit-year) match keeps the legacy string form, which rejects it.
+							this.date =
+								date.length === 8 ? new Date(+year, +month - 1, +day, 0, 0, 0, 0) : new Date(`${year}-${month}-${day} 00:00:00`);
 							this.detected_format = format_types['YYYYMMDD'];
 						} else if (isValid(date, format_types['YYYY-MM'])) {
 							const [year, month] = date.split('-');
-							this.date = new Date(`${year}-${month}-01 00:00:00`);
+							this.date = fastLocalDate(year, month, '01');
 							this.detected_format = format_types['YYYY-MM'];
 						} else if (isValid(date, format_types['DD MMMM dddd'])) {
 							const currentYear = new Date().getFullYear();
@@ -380,7 +439,7 @@ class KkDate {
 							this.detected_format = format_types['DD MMMM dddd'];
 						} else if (isValid(date, format_types['YYYY-DD-MM'])) {
 							const [year, day, month] = date.split('-');
-							this.date = new Date(`${year}-${month}-${day} 00:00:00`);
+							this.date = fastLocalDate(year, month, day);
 							this.detected_format = format_types['YYYY-DD-MM'];
 						} else if (isValid(date, format_types['D MMMM YYYY'])) {
 							const parts = date.split(' '); // e.g., ['1', 'January', '2024'] or ['01', 'January', '2024']
@@ -389,14 +448,14 @@ class KkDate {
 							const month = isValidMonth(parts[1]);
 							this.date = new Date(`${year}-${month}-${day.padStart(2, '0')} 00:00:00`); // Ensure day is padded for Date constructor
 							this.detected_format = format_types['D MMMM YYYY'];
-						} else if (isValid(date, format_types['YYYY MMM DD']) || isValid(date, format_types['YYYY MMMM DD'])) {
+						} else if (isValid(date, format_types['YYYY MMM DD'])) {
 							const parts = date.split(' ');
 							const year = parts[0];
 							const month = isValidMonth(parts[1]);
 							const day = parts[2];
 							this.date = new Date(`${year}-${month}-${day.padStart(2, '0')} 00:00:00`); // Ensure day is padded for Date constructor
 							this.detected_format = format_types['YYYY MMM DD'];
-						} else if (isValid(date, format_types['Do MMM YYYY']) || isValid(date, format_types['Do MMM YYYY'])) {
+						} else if (isValid(date, format_types['Do MMM YYYY'])) {
 							const parts = date.split(' ');
 							const day = parseInt(parts[0], 10).toString();
 							const month = isValidMonth(parts[1]);
@@ -436,8 +495,8 @@ class KkDate {
 				this.date = new Date(cached.getTime());
 			} else {
 				isInvalid(this.date);
-				if (is_can_cache) {
-					nopeRedis.setItemAsync(`${date}`, new Date(this.date.getTime()));
+				if (is_can_cache && cachingEnabled) {
+					nopeRedis.setItemSync(`${date}`, new Date(this.date.getTime()));
 				}
 			}
 		}
@@ -1444,48 +1503,38 @@ function diff(start, end, type, is_decimal = false, turn_difftime = false) {
 function formatter(orj_this, template = null) {
 	isInvalid(orj_this.date);
 
-	// Cache key for formatter results
 	const timestamp = orj_this.date.getTime();
+
+	// Unix timestamp templates need only the timestamp — return before building the (heavier) cache key.
+	if (template === 'x') {
+		// Unix timestamp in milliseconds - always UTC, no timezone conversion
+		return timestamp;
+	}
+	if (template === 'X') {
+		// Unix timestamp in seconds - always UTC, no timezone conversion
+		return Math.floor(timestamp / 1000);
+	}
+
+	// Cache key for formatter results
 	const timezone = orj_this.temp_config.timezone || global_config.timezone || 'none';
 	const locale = orj_this.temp_config.locale || global_config.locale || 'none';
 	const cacheKey = `${template}_${timestamp}_${timezone}_${locale}_${orj_this.detected_format || 'none'}`;
 
-	// Check cache first
-	if (formatter_cache.has(cacheKey)) {
-		return formatter_cache.get(cacheKey);
+	// Check cache first (single lookup)
+	const cachedResult = formatter_cache.get(cacheKey);
+	if (cachedResult !== undefined) {
+		return cachedResult;
 	}
 
 	// Limit cache size to prevent memory leaks
 	if (formatter_cache.size > 10000) {
-		// Clear half of the cache when limit is reached
-		const keysToDelete = Array.from(formatter_cache.keys()).slice(0, 5000);
-		for (const key of keysToDelete) {
-			formatter_cache.delete(key);
-		}
+		formatter_cache.clear();
 	}
-
-	let result;
 
 	// Determine if this is a UTC date (ISO8601 format) or if timezone is explicitly UTC
 	const isUTC = orj_this.detected_format === 'ISO8601' || timezone === 'UTC';
 
-	switch (template) {
-		case 'x': {
-			// Unix timestamp in milliseconds - always UTC, no timezone conversion
-			result = orj_this.date.getTime();
-			break;
-		}
-		case 'X': {
-			// Unix timestamp in seconds - always UTC, no timezone conversion
-			result = Math.floor(orj_this.date.getTime() / 1000);
-			break;
-		}
-		default: {
-			// Store result in cache and return
-			result = _formatterCore(orj_this, template, isUTC);
-			break;
-		}
-	}
+	const result = _formatterCore(orj_this, template, isUTC);
 
 	// Store result in cache
 	formatter_cache.set(cacheKey, result);
@@ -1502,7 +1551,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const value = formatter.value.format(orj_this.date);
-			nopeRedis.setItemAsync(cache_key, value);
+			nopeRedis.setItemSync(cache_key, value);
 			return value;
 		}
 		case format_types.DD: {
@@ -1720,7 +1769,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			const result = converter(orj_this.date, ['day', 'year'], { isUTC, detectedFormat: orj_this.detected_format, orj_this: orj_this });
 			return `${result.day} ${formatted} ${result.year}`;
@@ -1735,7 +1784,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const formatted = `${result.day} ${monthValue.value.format(orj_this.date)} ${result.year} ${dayValue.value.format(orj_this.date)}`;
-			nopeRedis.setItemAsync(cache_key, formatted);
+			nopeRedis.setItemSync(cache_key, formatted);
 			return formatted;
 		}
 		case format_types['DD MMM YYYY dddd']: {
@@ -1748,7 +1797,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const formatted = `${result.day} ${monthValue.value.format(orj_this.date)} ${result.year} ${dayValue.value.format(orj_this.date)}`;
-			nopeRedis.setItemAsync(cache_key, formatted);
+			nopeRedis.setItemSync(cache_key, formatted);
 			return formatted;
 		}
 		case format_types['MMMM YYYY']: {
@@ -1760,7 +1809,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			const result = converter(orj_this.date, ['year'], { isUTC, detectedFormat: orj_this.detected_format, orj_this: orj_this });
 			return `${formatted} ${result.year}`;
@@ -1775,7 +1824,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const formatted = `${result.day} ${monthValue.value.format(orj_this.date)} ${dayValue.value.format(orj_this.date)} ${result.year}`;
-			nopeRedis.setItemAsync(cache_key, formatted);
+			nopeRedis.setItemSync(cache_key, formatted);
 			return formatted;
 		}
 		case format_types['DD MMM dddd, YYYY']: {
@@ -1788,7 +1837,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const formatted = `${result.day} ${monthValue.value.format(orj_this.date)} ${dayValue.value.format(orj_this.date)}, ${result.year}`;
-			nopeRedis.setItemAsync(cache_key, formatted);
+			nopeRedis.setItemSync(cache_key, formatted);
 			return formatted;
 		}
 		case format_types['MMM']: {
@@ -1799,7 +1848,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const value = formatter.value.format(orj_this.date);
-			nopeRedis.setItemAsync(cache_key, value);
+			nopeRedis.setItemSync(cache_key, value);
 			return value;
 		}
 		case format_types['MMMM']: {
@@ -1810,7 +1859,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const value = formatter.value.format(orj_this.date);
-			nopeRedis.setItemAsync(cache_key, value);
+			nopeRedis.setItemSync(cache_key, value);
 			return value;
 		}
 		case format_types['ddd']: {
@@ -1821,7 +1870,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const value = formatter.value.format(orj_this.date);
-			nopeRedis.setItemAsync(cache_key, value);
+			nopeRedis.setItemSync(cache_key, value);
 			return value;
 		}
 		case format_types['DD MMM YYYY']: {
@@ -1834,7 +1883,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${result.day} ${formatted} ${result.year}`;
 		}
@@ -1848,7 +1897,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${result.day} ${formatted}`;
 		}
@@ -1861,7 +1910,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${formatted} ${converter(orj_this.date, ['year'], { isUTC, detectedFormat: orj_this.detected_format, orj_this: orj_this }).year}`;
 		}
@@ -1875,7 +1924,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const formatted = `${dayValue.value.format(orj_this.date)}, ${result.day} ${monthValue.value.format(orj_this.date)} ${result.year}`;
-			nopeRedis.setItemAsync(cache_key, formatted);
+			nopeRedis.setItemSync(cache_key, formatted);
 			return formatted;
 		}
 		case format_types['DD MMM YYYY HH:mm']: {
@@ -1892,7 +1941,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${result.day} ${formatted} ${result.year} ${result.hours}:${result.minutes}`;
 		}
@@ -1910,7 +1959,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const result = `${day} ${monthValue.value.format(orj_this.date)} ${dayValue.value.format(orj_this.date)}`;
-			nopeRedis.setItemAsync(cache_key, result);
+			nopeRedis.setItemSync(cache_key, result);
 			return result;
 		}
 		case format_types['YYYY-DD-MM']: {
@@ -1927,7 +1976,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${result.day} ${formatted}`;
 		}
@@ -1942,7 +1991,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${day} ${formatted} ${year}`;
 		}
@@ -1957,7 +2006,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${getOrdinal(parseInt(day, 10))} ${formatted} ${year}`;
 		}
@@ -1972,7 +2021,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${getOrdinal(parseInt(day, 10))} ${formatted} ${year}`;
 		}
@@ -1986,7 +2035,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				return cache;
 			}
 			const formatted = `${result.day} ${monthValue.value.format(orj_this.date)} ${dayValue.value.format(orj_this.date)}, ${result.year}`;
-			nopeRedis.setItemAsync(cache_key, formatted);
+			nopeRedis.setItemSync(cache_key, formatted);
 			return formatted;
 		}
 		case format_types['YYYY MMM DD']: {
@@ -1999,7 +2048,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${result.year} ${formatted} ${result.day}`;
 		}
@@ -2013,7 +2062,7 @@ function _formatterCore(orj_this, template, isUTC) {
 				formatted = cache;
 			} else {
 				formatted = value.value.format(orj_this.date);
-				nopeRedis.setItemAsync(cache_key, formatted);
+				nopeRedis.setItemSync(cache_key, formatted);
 			}
 			return `${result.year} ${formatted} ${result.day}`;
 		}
@@ -2066,16 +2115,11 @@ function isValid(date_string, template) {
 		return true;
 	}
 
-	// Cache format_types lookup to avoid repeated property access
-	const formatType = format_types_cache.has(template);
-	if (!formatType) {
-		throw new Error('Invalid template !');
-	}
-
-	// Cache regex lookup to avoid repeated property access
+	// Single Map lookup: format_types and format_types_regex share the same keys (except 'dddd',
+	// handled above), so a missing regex means the template is unknown.
 	const regex = format_types_regex_cache.get(template);
 	if (!regex) {
-		throw new Error('Unsupported template for validation !');
+		throw new Error('Invalid template !');
 	}
 
 	// Direct return for better performance
@@ -2158,8 +2202,10 @@ function caching(options = { status: false, defaultTtl: null }) {
 	if (typeof options.status === 'boolean') {
 		if (options.status) {
 			nopeRedis.SERVICE_START();
+			cachingEnabled = true;
 		} else {
 			nopeRedis.SERVICE_KILL_SYNC();
+			cachingEnabled = false;
 		}
 	}
 	if (typeof options.defaultTtl === 'number') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
 			"version": "4.1.3",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.4.6"
+				"@biomejs/biome": "2.4.6",
+				"dayjs": "^1.11.19",
+				"luxon": "^3.7.2",
+				"moment-timezone": "^0.6.0"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -173,6 +176,46 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.21",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+			"integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/luxon": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+			"integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/moment-timezone": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.2.tgz",
+			"integrity": "sha512-lDsQv8FoGdBUdf0+TjGsq2orxKuXdwFlQ6Zw6TX3xIcTwTfEpCLyKqvEauvCHJ8iu3KBV8+uPhlv70YsNGdUBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"moment": "^2.29.4"
+			},
+			"engines": {
+				"node": "*"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kk-date",
-	"version": "4.1.3",
+	"version": "4.2.0",
 	"description": "kk-date is a fastest JavaScript library that parses, validations, manipulates, and displays dates and times. If you use Moment.js or Day.js already you can easily use kk-date.",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
 	"description": "kk-date is a fastest JavaScript library that parses, validations, manipulates, and displays dates and times. If you use Moment.js or Day.js already you can easily use kk-date.",
 	"main": "index.js",
 	"types": "index.d.ts",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"test": "npx jest",
 		"test:coverage": "npx jest --coverage",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
 	},
 	"homepage": "https://github.com/kentkartlab/kk-date#readme",
 	"devDependencies": {
-		"@biomejs/biome": "2.4.6"
+		"@biomejs/biome": "2.4.6",
+		"dayjs": "^1.11.19",
+		"luxon": "^3.7.2",
+		"moment-timezone": "^0.6.0"
 	}
 }

--- a/scripts/update-benchmark-docs.js
+++ b/scripts/update-benchmark-docs.js
@@ -130,6 +130,55 @@ function cacheBullets(comp) {
 	].join('\n');
 }
 
+// Headline stats derived from both benchmark JSONs (used by the prose-bullet regions).
+function derived(seq, comp) {
+	const fp = comp.overall.kkDateFasterPct; // kk-date is X% faster than each competitor (comprehensive)
+	const avgFaster = round((fp.Moment + fp['Day.js'] + fp.Luxon) / 3);
+	const tz = seq.scenarios['Timezone Conversions'];
+	const kkTz = tz['kk-date'];
+	// "% faster" here = how much LESS time kk-date takes than a competitor: (1 - kk/comp) * 100.
+	const tzMaxFaster = round(Math.max(...COMPETS.map((c) => (1 - kkTz / tz[c]) * 100)));
+	const tzX = tz['Day.js'] / kkTz; // kk-date is this many TIMES faster than Day.js at tz conversion
+	const tzXfloor = Math.floor(tzX / 10) * 10; // stable "over Nx" (only moves when it crosses a decade)
+	const tzXpct = round(tzX - 1) * 100; // Day.js takes ~this many % MORE time
+	const cachePct = round(comp.cache.improvementPct);
+	return { avgFaster, tzMaxFaster, tzXfloor, tzXpct, cachePct };
+}
+
+function whyBullets(seq, comp) {
+	const d = derived(seq, comp);
+	return [
+		`- **⚡ Lightning Fast** - Over ${d.tzXfloor}x faster timezone operations than Day.js`,
+		`- **🚀 ~${d.avgFaster}% Faster Overall** - Wins most scenarios vs Moment.js, Day.js, and Luxon (Day.js is faster in isolated "Time Operations")`,
+		'- **💾 Memory Efficient** - Object pooling + LRU cache eviction keep long-running processes stable',
+		`- **⚙️ Smart Caching** - ~${d.cachePct}% faster repeated operations with built-in caching`,
+	].join('\n');
+}
+
+function advantagesBullets(seq, comp) {
+	const d = derived(seq, comp);
+	return [
+		`- **⚡ ~${d.avgFaster}% faster** than the average of competing libraries (comprehensive benchmark)`,
+		`- **🚀 up to ~${d.tzMaxFaster}% faster** in timezone operations (critical for global apps)`,
+		'- **📊 Big-data ready** - efficient for bulk/1M-operation workloads',
+		'- **💾 Stable memory** - object pooling + LRU eviction; net heap delta is GC-dependent (often negative)',
+		`- **⚙️ ~${d.cachePct}% boost** with smart caching enabled`,
+		`- **🌍 Over ${d.tzXfloor}x faster** (≈${d.tzXpct}%) than Day.js in timezone conversions`,
+	].join('\n');
+}
+
+function perfMetricsBullets(seq, comp) {
+	const d = derived(seq, comp);
+	return [
+		`- **~${d.avgFaster}% faster** than the average of competing libraries (comprehensive benchmark)`,
+		`- **up to ~${d.tzMaxFaster}% faster** in timezone operations`,
+		`- **~${d.cachePct}% faster** with caching enabled`,
+		'- **kk-date does not win every scenario** — Day.js is faster in isolated "Time Operations"',
+		'- **Net memory delta is GC-dependent** (often negative for several libraries); stability comes from object pooling + LRU eviction',
+		'- **Near-100% cache hit rate** for repeated operations',
+	].join('\n');
+}
+
 // ---- marker replacement ----
 function replaceRegion(content, id, body) {
 	const start = `<!-- BENCH:${id} -->`;
@@ -159,6 +208,15 @@ function main() {
 	if (comp?.memory) readme = replaceRegion(readme, 'readme-memory', memoryTable(comp));
 	if (comp?.cache) readme = replaceRegion(readme, 'readme-cache', cacheBullets(comp));
 	if (!comp) console.warn('  ! no comprehensive benchmark data — skipped memory/cache');
+
+	// Prose headline bullets need BOTH benchmarks (avg-faster + timezone + cache).
+	if (seq?.scenarios && comp?.overall && comp?.cache) {
+		readme = replaceRegion(readme, 'readme-why', whyBullets(seq, comp));
+		readme = replaceRegion(readme, 'readme-advantages', advantagesBullets(seq, comp));
+		perf = replaceRegion(perf, 'perf-metrics', perfMetricsBullets(seq, comp));
+	} else {
+		console.warn('  ! need both benchmarks for headline bullets — skipped why/advantages/metrics');
+	}
 
 	fs.writeFileSync(README, readme);
 	fs.writeFileSync(PERF, perf);

--- a/scripts/update-benchmark-docs.js
+++ b/scripts/update-benchmark-docs.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Refreshes the auto-generated performance tables in README.md and docs/PERFORMANCE.md
+ * from real benchmark results. Only the regions between HTML markers
+ *   <!-- BENCH:id --> ... <!-- /BENCH:id -->
+ * are rewritten; all surrounding prose/qualifiers are left untouched.
+ *
+ * Usage:
+ *   node scripts/update-benchmark-docs.js <comprehensive.json> <sequential.json>
+ *     - JSON files produced by `node benchmark.js --json` / `node benchmark2.js --json`
+ *       (order-independent; detected by each file's `type` field).
+ *   node scripts/update-benchmark-docs.js
+ *     - with no args, runs both benchmarks itself (slow).
+ *
+ * Run by the "Update Benchmark Docs" workflow on PRs to `dev`.
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const README = path.join(ROOT, 'README.md');
+const PERF = path.join(ROOT, 'docs', 'PERFORMANCE.md');
+
+// Static (non-benchmark) columns for the memory table.
+const BUNDLE = { 'kk-date': '15 KB', 'Moment.js': '297 KB', 'Day.js': '18.5 KB', Luxon: '71 KB' };
+const DST = { 'kk-date': 'Built-in', 'Moment.js': 'Plugin required', 'Day.js': 'Plugin required', Luxon: 'Built-in' };
+
+const SEQ_ORDER = ['Date Creation & Formatting', 'Time Operations', 'Timezone Conversions', 'Complex Operations'];
+const LIBS = ['kk-date', 'Moment', 'Day.js', 'Luxon'];
+const COMPETS = ['Moment', 'Day.js', 'Luxon'];
+
+const round = (v) => Math.round(v);
+const secs = (ms) => `${(ms / 1000).toFixed(2)}s`;
+const ops = (n) => n.toLocaleString('en-US');
+
+function loadInputs() {
+	const args = process.argv.slice(2);
+	let seq = null;
+	let comp = null;
+	if (args.length) {
+		for (const a of args) {
+			const j = JSON.parse(fs.readFileSync(a, 'utf8'));
+			if (j.type === 'sequential') seq = j;
+			else if (j.type === 'comprehensive') comp = j;
+		}
+	} else {
+		const run = (s) =>
+			JSON.parse(execFileSync('node', [path.join(ROOT, s), '--json'], { cwd: ROOT, encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 }));
+		console.log('Running benchmark2.js --json ...');
+		seq = run('benchmark2.js');
+		console.log('Running benchmark.js --json ...');
+		comp = run('benchmark.js');
+	}
+	return { seq, comp };
+}
+
+// ---- table generators ----
+function seqRows(seq) {
+	return SEQ_ORDER.map((name) => {
+		const s = seq.scenarios[name];
+		const min = Math.min(...LIBS.map((l) => s[l]));
+		const cell = (l) => (s[l] === min ? `**${round(s[l])}ms**` : `${round(s[l])}ms`);
+		let fc = COMPETS[0];
+		for (const c of COMPETS) if (s[c] < s[fc]) fc = c;
+		const vs =
+			s['kk-date'] <= s[fc]
+				? `**~${round(((s[fc] - s['kk-date']) / s['kk-date']) * 100)}% faster** than ${fc}`
+				: `**~${round(((s['kk-date'] - s[fc]) / s[fc]) * 100)}% slower** than ${fc}`;
+		return `| **${name}** | ${cell('kk-date')} | ${cell('Moment')} | ${cell('Day.js')} | ${cell('Luxon')} | ${vs} |`;
+	});
+}
+
+function seqTable(seq) {
+	return [
+		'| Operation | kk-date | Moment.js | Day.js | Luxon | vs Fastest Competitor |',
+		'|-----------|---------|-----------|--------|-------|-----------------------|',
+		...seqRows(seq),
+	].join('\n');
+}
+
+function overallTable(seq) {
+	const o = seq.overall;
+	const kk = o['kk-date'];
+	const sortedComps = COMPETS.slice().sort((a, b) => o[a].ms - o[b].ms);
+	const slowest = sortedComps[sortedComps.length - 1];
+	const display = (c) => (c === 'Moment' ? 'Moment.js' : c);
+	const rows = [`| **kk-date** | **${secs(kk.ms)}** | **${ops(kk.ops)} ops/sec** | 🏆 **Winner** |`];
+	for (const c of sortedComps) {
+		const pct = round(((o[c].ms - kk.ms) / kk.ms) * 100);
+		const perf = c === slowest ? `**~${pct}% slower**` : `~${pct}% slower`;
+		rows.push(`| ${display(c)} | ${secs(o[c].ms)} | ${ops(o[c].ops)} ops/sec | ${perf} |`);
+	}
+	return ['| Library | Total Time | Operations/sec | Performance |', '|---------|------------|---------------|-------------|', ...rows].join('\n');
+}
+
+function perfSeqTable(seq) {
+	const o = seq.overall;
+	const x = (o['Day.js'].ms / o['kk-date'].ms).toFixed(1);
+	const overallRow = `| **Overall** | **${secs(o['kk-date'].ms)}** | ${secs(o['Moment'].ms)} | ${secs(o['Day.js'].ms)} | ${secs(o['Luxon'].ms)} | **~${x}x faster** than Day.js |`;
+	return `${seqTable(seq)}\n${overallRow}`;
+}
+
+function memoryTable(comp) {
+	const mem = comp.memory;
+	const fmt = (v) => {
+		const r = round(v);
+		const sign = r > 0 ? '+' : r < 0 ? '-' : '';
+		return `~${sign}${Math.abs(r)} MB${r < 0 ? '*' : ''}`;
+	};
+	const rows = [
+		`| **kk-date** | ${fmt(mem['kk-date'])} | **${BUNDLE['kk-date']}** | **${DST['kk-date']}** |`,
+		`| Moment.js | ${fmt(mem['Moment'])} | ${BUNDLE['Moment.js']} | ${DST['Moment.js']} |`,
+		`| Day.js | ${fmt(mem['Day.js'])} | ${BUNDLE['Day.js']} | ${DST['Day.js']} |`,
+		`| Luxon | ${fmt(mem['Luxon'])} | ${BUNDLE['Luxon']} | ${DST['Luxon']} |`,
+	];
+	return [
+		'| Library | Heap Δ / 100k instances* | Bundle Size | DST Support |',
+		'|---------|--------------------------|-------------|-------------|',
+		...rows,
+	].join('\n');
+}
+
+function cacheBullets(comp) {
+	const c = comp.cache;
+	return [
+		`- **~${round(c.improvementPct)}% faster** repeated operations when cache is enabled`,
+		`- Average operation time: ~${round(c.withoutMs)}ms → ~${round(c.withMs)}ms with cache`,
+		`- Cache hit ratio: **${round(c.hitRatioPct)}%** for repeated operations`,
+	].join('\n');
+}
+
+// ---- marker replacement ----
+function replaceRegion(content, id, body) {
+	const start = `<!-- BENCH:${id} -->`;
+	const end = `<!-- /BENCH:${id} -->`;
+	const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const re = new RegExp(`${esc(start)}[\\s\\S]*?${esc(end)}`);
+	if (!re.test(content)) {
+		console.warn(`  ! marker not found: ${id} (skipped)`);
+		return content;
+	}
+	return content.replace(re, `${start}\n${body}\n${end}`);
+}
+
+function main() {
+	const { seq, comp } = loadInputs();
+
+	let readme = fs.readFileSync(README, 'utf8');
+	let perf = fs.readFileSync(PERF, 'utf8');
+
+	if (seq?.scenarios && seq?.overall) {
+		readme = replaceRegion(readme, 'readme-seq', seqTable(seq));
+		readme = replaceRegion(readme, 'readme-overall', overallTable(seq));
+		perf = replaceRegion(perf, 'perf-seq', perfSeqTable(seq));
+	} else {
+		console.warn('  ! no sequential benchmark data — skipped seq/overall/perf tables');
+	}
+	if (comp?.memory) readme = replaceRegion(readme, 'readme-memory', memoryTable(comp));
+	if (comp?.cache) readme = replaceRegion(readme, 'readme-cache', cacheBullets(comp));
+	if (!comp) console.warn('  ! no comprehensive benchmark data — skipped memory/cache');
+
+	fs.writeFileSync(README, readme);
+	fs.writeFileSync(PERF, perf);
+	console.log('Benchmark docs refreshed: README.md, docs/PERFORMANCE.md');
+}
+
+main();


### PR DESCRIPTION
## %40-50 performance improved
1. .diff() sign fix (b − a) across README + API-REFERENCE
2. Static isValid() requires format template
3. startOf/endOf('weeks') default Sunday
4. add('weeks') support (code + docs)
5. Global config({weekStartDay}) works without locale (code)
6. format() exact-template docs (removed fake custom-format sections)
7. 12-hour hh* formats show AM/PM
8. fr/es weekday lowercase
9. Error message 'Invalid Date'
10. getTimezoneInfo 6-key object
11. clearCache → caching_flush
12. Non-leap Feb 29 rolls over (valid)
13. .tz() mutation/aliasing documented
14. config({timezone}) display-only clarified
15. Timezone examples pinned to UTC baseline / ISO-Z instants
16. Test count 322 → 499
17. CLAUDE.md .tz() line corrected
18. Full verification (499 tests, 206 doc assertions)
19. Competitors added to devDependencies (dayjs/luxon/moment-timezone)
20. Doc performance numbers refreshed from real runs
21. Marketing claims qualified (memory/cache/speed)
22. CLAUDE.md reviewed line-by-line + "API Gotchas" section added
23. --json mode added to benchmark.js + benchmark2.js
24. scripts/update-benchmark-docs.js (idempotent, marker-based)
25. Benchmark markers around doc tables
26. .github/workflows/update-benchmarks.yml (PR-to-dev, test-gated, auto-commit)
27. Redundant benchmarks job removed from pr-checks.yml
28. .gitignore: bench-*.json